### PR TITLE
Release Animus CLI v0.7.0-rc.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,7 +2898,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.7.0-rc.41"
+version = "0.7.0-rc.42"
 dependencies = [
  "animus-actor",
  "animus-application-protocol",

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.7.0-rc.41"
+version = "0.7.0-rc.42"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"


### PR DESCRIPTION
Version bump for v0.7.0-rc.42, shipping #388 (expired recovered leases never block fresh queue dispatch, TASK-1332).