### PR TITLE
feat(environment): default reap passes live journal run ids (owner-known mode) (TASK-1466)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "animus-actor"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
  "schemars",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 name = "animus-application-protocol"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
  "schemars",
  "serde",
@@ -89,7 +89,7 @@ dependencies = [
 [[package]]
 name = "animus-config-protocol"
 version = "0.2.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
  "animus-actor",
  "animus-application-protocol",
@@ -105,12 +105,12 @@ dependencies = [
 [[package]]
 name = "animus-control-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
  "animus-actor",
- "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-execution-protocol",
  "animus-log-storage-protocol",
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "animus-subject-protocol",
  "animus-trigger-protocol",
  "anyhow",
@@ -126,10 +126,10 @@ dependencies = [
 [[package]]
 name = "animus-environment-protocol"
 version = "0.2.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=task-1466%2Freap-live-run-ids#21f623c07b83d7a16abc228e88ace35fb16c8131"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
- "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?branch=task-1466%2Freap-live-run-ids)",
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?branch=task-1466%2Freap-live-run-ids)",
+ "animus-execution-protocol",
+ "animus-plugin-protocol",
  "schemars",
  "serde",
  "serde_json",
@@ -138,18 +138,7 @@ dependencies = [
 [[package]]
 name = "animus-execution-protocol"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
-dependencies = [
- "chrono",
- "schemars",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "animus-execution-protocol"
-version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=task-1466%2Freap-live-run-ids#21f623c07b83d7a16abc228e88ace35fb16c8131"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
  "chrono",
  "schemars",
@@ -160,9 +149,9 @@ dependencies = [
 [[package]]
 name = "animus-journal-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "anyhow",
  "async-trait",
  "chrono",
@@ -175,9 +164,9 @@ dependencies = [
 [[package]]
 name = "animus-log-storage-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "anyhow",
  "async-trait",
  "chrono",
@@ -217,17 +206,7 @@ dependencies = [
 [[package]]
 name = "animus-plugin-protocol"
 version = "0.1.18"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
-dependencies = [
- "schemars",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "animus-plugin-protocol"
-version = "0.1.18"
-source = "git+https://github.com/launchapp-dev/animus-protocol?branch=task-1466%2Freap-live-run-ids#21f623c07b83d7a16abc228e88ace35fb16c8131"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
  "schemars",
  "serde",
@@ -238,7 +217,7 @@ dependencies = [
 name = "animus-plugin-runtime"
 version = "0.1.0"
 dependencies = [
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "animus-session-backend",
  "anyhow",
  "async-trait",
@@ -251,10 +230,10 @@ dependencies = [
 [[package]]
 name = "animus-queue-protocol"
 version = "0.4.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
- "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-execution-protocol",
+ "animus-plugin-protocol",
  "animus-subject-protocol",
  "schemars",
  "serde",
@@ -267,7 +246,7 @@ version = "0.1.0"
 dependencies = [
  "animus-actor",
  "animus-environment-protocol",
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "animus-runtime-utils",
  "anyhow",
  "async-trait",
@@ -299,10 +278,10 @@ version = "0.1.0"
 [[package]]
 name = "animus-session-backend"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
  "animus-actor",
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "anyhow",
  "async-trait",
  "serde",
@@ -316,10 +295,10 @@ dependencies = [
 [[package]]
 name = "animus-subject-protocol"
 version = "0.2.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
  "animus-actor",
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "anyhow",
  "async-trait",
  "chrono",
@@ -333,9 +312,9 @@ dependencies = [
 [[package]]
 name = "animus-trigger-protocol"
 version = "0.1.15"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "anyhow",
  "async-trait",
  "chrono",
@@ -349,11 +328,11 @@ dependencies = [
 [[package]]
 name = "animus-workflow-runner-protocol"
 version = "0.4.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
  "animus-actor",
- "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-execution-protocol",
+ "animus-plugin-protocol",
  "animus-subject-protocol",
  "chrono",
  "schemars",
@@ -2925,10 +2904,10 @@ dependencies = [
  "animus-application-protocol",
  "animus-control-protocol",
  "animus-environment-protocol",
- "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-execution-protocol",
  "animus-log-storage-protocol",
  "animus-mcp-oauth",
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "animus-plugin-runtime",
  "animus-queue-protocol",
  "animus-runtime-shared",
@@ -3001,7 +2980,7 @@ dependencies = [
  "animus-actor",
  "animus-environment-protocol",
  "animus-journal-protocol",
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "anyhow",
  "argon2",
  "async-trait",
@@ -3039,9 +3018,9 @@ dependencies = [
  "animus-actor",
  "animus-config-protocol",
  "animus-control-protocol",
- "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-execution-protocol",
  "animus-log-storage-protocol",
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "animus-runtime-shared",
  "animus-subject-protocol",
  "anyhow",
@@ -3090,7 +3069,7 @@ name = "orchestrator-plugin-host"
 version = "0.1.0"
 dependencies = [
  "animus-actor",
- "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol",
  "animus-runtime-utils",
  "animus-session-backend",
  "animus-subject-protocol",
@@ -3387,9 +3366,9 @@ dependencies = [
 [[package]]
 name = "protocol"
 version = "0.1.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.43#88ee00a922b80fb785424b1f2d3231cb09a57ca7"
 dependencies = [
- "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-execution-protocol",
  "animus-subject-protocol",
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ version = "0.1.15"
 source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
 dependencies = [
  "animus-actor",
- "animus-execution-protocol",
+ "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-log-storage-protocol",
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-subject-protocol",
  "animus-trigger-protocol",
  "anyhow",
@@ -126,10 +126,10 @@ dependencies = [
 [[package]]
 name = "animus-environment-protocol"
 version = "0.2.0"
-source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=task-1466%2Freap-live-run-ids#21f623c07b83d7a16abc228e88ace35fb16c8131"
 dependencies = [
- "animus-execution-protocol",
- "animus-plugin-protocol",
+ "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?branch=task-1466%2Freap-live-run-ids)",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?branch=task-1466%2Freap-live-run-ids)",
  "schemars",
  "serde",
  "serde_json",
@@ -147,11 +147,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "animus-execution-protocol"
+version = "0.1.0"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=task-1466%2Freap-live-run-ids#21f623c07b83d7a16abc228e88ace35fb16c8131"
+dependencies = [
+ "chrono",
+ "schemars",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "animus-journal-protocol"
 version = "0.1.15"
 source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
 dependencies = [
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "anyhow",
  "async-trait",
  "chrono",
@@ -166,7 +177,7 @@ name = "animus-log-storage-protocol"
 version = "0.1.15"
 source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
 dependencies = [
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "anyhow",
  "async-trait",
  "chrono",
@@ -214,10 +225,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "animus-plugin-protocol"
+version = "0.1.18"
+source = "git+https://github.com/launchapp-dev/animus-protocol?branch=task-1466%2Freap-live-run-ids#21f623c07b83d7a16abc228e88ace35fb16c8131"
+dependencies = [
+ "schemars",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "animus-plugin-runtime"
 version = "0.1.0"
 dependencies = [
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-session-backend",
  "anyhow",
  "async-trait",
@@ -232,8 +253,8 @@ name = "animus-queue-protocol"
 version = "0.4.0"
 source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
 dependencies = [
- "animus-execution-protocol",
- "animus-plugin-protocol",
+ "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-subject-protocol",
  "schemars",
  "serde",
@@ -246,7 +267,7 @@ version = "0.1.0"
 dependencies = [
  "animus-actor",
  "animus-environment-protocol",
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-runtime-utils",
  "anyhow",
  "async-trait",
@@ -281,7 +302,7 @@ version = "0.1.15"
 source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
 dependencies = [
  "animus-actor",
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "anyhow",
  "async-trait",
  "serde",
@@ -298,7 +319,7 @@ version = "0.2.0"
 source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
 dependencies = [
  "animus-actor",
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "anyhow",
  "async-trait",
  "chrono",
@@ -314,7 +335,7 @@ name = "animus-trigger-protocol"
 version = "0.1.15"
 source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
 dependencies = [
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "anyhow",
  "async-trait",
  "chrono",
@@ -331,8 +352,8 @@ version = "0.4.0"
 source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
 dependencies = [
  "animus-actor",
- "animus-execution-protocol",
- "animus-plugin-protocol",
+ "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-subject-protocol",
  "chrono",
  "schemars",
@@ -2904,10 +2925,10 @@ dependencies = [
  "animus-application-protocol",
  "animus-control-protocol",
  "animus-environment-protocol",
- "animus-execution-protocol",
+ "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-log-storage-protocol",
  "animus-mcp-oauth",
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-plugin-runtime",
  "animus-queue-protocol",
  "animus-runtime-shared",
@@ -2980,7 +3001,7 @@ dependencies = [
  "animus-actor",
  "animus-environment-protocol",
  "animus-journal-protocol",
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "anyhow",
  "argon2",
  "async-trait",
@@ -3018,9 +3039,9 @@ dependencies = [
  "animus-actor",
  "animus-config-protocol",
  "animus-control-protocol",
- "animus-execution-protocol",
+ "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-log-storage-protocol",
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-runtime-shared",
  "animus-subject-protocol",
  "anyhow",
@@ -3069,7 +3090,7 @@ name = "orchestrator-plugin-host"
 version = "0.1.0"
 dependencies = [
  "animus-actor",
- "animus-plugin-protocol",
+ "animus-plugin-protocol 0.1.18 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-runtime-utils",
  "animus-session-backend",
  "animus-subject-protocol",
@@ -3368,7 +3389,7 @@ name = "protocol"
 version = "0.1.0"
 source = "git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14#63c60d573090a98c1a36c8f469e86e0dbcd6c712"
 dependencies = [
- "animus-execution-protocol",
+ "animus-execution-protocol 0.1.0 (git+https://github.com/launchapp-dev/animus-protocol?tag=v0.7.0-rc.14)",
  "animus-subject-protocol",
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,11 @@ animus-actor = { git = "https://github.com/launchapp-dev/animus-protocol", tag =
 animus-application-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
 animus-config-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
 animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-environment-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
+# TEMPORARY (TASK-1466): pinned to the `task-1466/reap-live-run-ids` BRANCH so
+# `ReapRequest.live_run_ids` is available before the next write-once protocol
+# tag. Before merge/release: merge animus-protocol PR #8, cut the new tag, and
+# repin this entry to `tag = "<new-tag>"`.
+animus-environment-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "task-1466/reap-live-run-ids" }
 animus-execution-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
 animus-journal-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
 animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,28 +29,24 @@ categories = ["command-line-utilities", "development-tools"]
 # this repo. Every dependency is pinned to the same release so Cargo resolves
 # one coherent wire identity with no workstation paths or legacy source split.
 animus-runtime-utils = { path = "crates/animus-runtime-utils" }
-animus-actor = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-application-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-config-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-# TEMPORARY (TASK-1466): pinned to the `task-1466/reap-live-run-ids` BRANCH so
-# `ReapRequest.live_run_ids` is available before the next write-once protocol
-# tag. Before merge/release: merge animus-protocol PR #8, cut the new tag, and
-# repin this entry to `tag = "<new-tag>"`.
-animus-environment-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", branch = "task-1466/reap-live-run-ids" }
-animus-execution-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-journal-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-plugin-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-provider-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-queue-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-session-backend = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
-animus-workflow-runner-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14" }
+animus-actor = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-application-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-config-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-control-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-environment-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-execution-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-journal-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-log-storage-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-plugin-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-provider-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-queue-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-session-backend = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-subject-protocol-wire = { package = "animus-subject-protocol", git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
+animus-workflow-runner-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43" }
 # v0.7: environment plugin kind — EnvironmentSpec/HarnessCommand/ExecRequest wire
 # types + prepare/exec/exec_stream/teardown methods. Consumed by the routing
 # resolver + the follow-on runtime EnvironmentClient (not yet built).
-protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.14", package = "protocol" }
+protocol = { git = "https://github.com/launchapp-dev/animus-protocol", tag = "v0.7.0-rc.43", package = "protocol" }
 orchestrator-daemon-runtime = { path = "crates/orchestrator-daemon-runtime" }
 orchestrator-logging = { path = "crates/orchestrator-logging" }
 orchestrator-plugin-host = { path = "crates/orchestrator-plugin-host" }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 Open a fresh **Claude Code** (or **Codex** / **OpenCode** / **Cursor**) session and paste this. The agent installs the Animus CLI, clones `animus-skills`, runs the setup script, and adds the project section to `CLAUDE.md` / `AGENTS.md`. You'll be running workflows in about a minute.
 
-> Install Animus + Animus Skills: run **`curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash`** to install the `animus` CLI (currently `v0.7.0-rc.40` in this repo), then **`animus plugin install-defaults`** to pull in the provider + subject + workflow_runner + queue plugins the daemon needs (one-time setup, idempotent; add `--include-recommended` for the web UI and extra providers). Then **`git clone --single-branch --depth 1 https://github.com/launchapp-dev/animus-skills.git ~/.claude/skills/animus-skills && cd ~/.claude/skills/animus-skills && ./setup`** to link the skills and write `.mcp.json`. Add an "Animus" section to CLAUDE.md (or AGENTS.md for Codex) listing the slash commands: `/animus-setup`, `/animus-getting-started`, `/animus-mcp-setup`, `/animus-workflow-authoring`, `/animus-pack-authoring`, `/animus-skill-authoring`, `/animus-troubleshooting`. Restart the agent so the new `animus` MCP server is picked up. From a project root, run `animus init --walkthrough` to scaffold `.animus/`, install packs, and optionally start the daemon.
+> Install Animus + Animus Skills: run **`curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash`** to install the `animus` CLI (currently `v0.7.0-rc.42` in this repo), then **`animus plugin install-defaults`** to pull in the provider + subject + workflow_runner + queue plugins the daemon needs (one-time setup, idempotent; add `--include-recommended` for the web UI and extra providers). Then **`git clone --single-branch --depth 1 https://github.com/launchapp-dev/animus-skills.git ~/.claude/skills/animus-skills && cd ~/.claude/skills/animus-skills && ./setup`** to link the skills and write `.mcp.json`. Add an "Animus" section to CLAUDE.md (or AGENTS.md for Codex) listing the slash commands: `/animus-setup`, `/animus-getting-started`, `/animus-mcp-setup`, `/animus-workflow-authoring`, `/animus-pack-authoring`, `/animus-skill-authoring`, `/animus-troubleshooting`. Restart the agent so the new `animus` MCP server is picked up. From a project root, run `animus init --walkthrough` to scaffold `.animus/`, install packs, and optionally start the daemon.
 
 For Codex CLI, swap the clone path to `~/.codex/skills/animus-skills` and edit `AGENTS.md` instead of `CLAUDE.md`.
 
@@ -83,7 +83,7 @@ animus install --locked
 
 ```bash
 # Specific version
-ANIMUS_VERSION=v0.7.0-rc.40 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
+ANIMUS_VERSION=v0.7.0-rc.42 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
 
 # Custom directory
 ANIMUS_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash

--- a/crates/orchestrator-cli/src/cli_types/environment_types.rs
+++ b/crates/orchestrator-cli/src/cli_types/environment_types.rs
@@ -12,8 +12,11 @@ pub(crate) enum EnvironmentCommand {
     Get(EnvironmentGetArgs),
     /// Destroy one managed node by substrate id or name (idempotent).
     Teardown(EnvironmentTeardownArgs),
-    /// Reap orphaned/dead nodes. Default reaps only dead (FAILED/CRASHED)
-    /// nodes; `--all --force` also reaps healthy nodes with no live owning run.
+    /// Reap orphaned/dead nodes. Default reaps dead (FAILED/CRASHED) nodes AND,
+    /// when the journal's live run set is readable, healthy (SUCCESS) nodes whose
+    /// owning workflow is terminal/gone (owner-known mode, plugin age grace
+    /// applies). `--all --force` keeps the legacy behavior: also reap healthy
+    /// nodes with no live owning run.
     Reap(EnvironmentReapArgs),
 }
 
@@ -43,7 +46,11 @@ pub(crate) struct EnvironmentTeardownArgs {
 
 #[derive(Debug, Args)]
 pub(crate) struct EnvironmentReapArgs {
-    /// Also reap non-dead nodes that have no live owning run (needs --force).
+    /// Also reap non-dead nodes that have no live owning run (needs --force),
+    /// WITHOUT consulting the journal's live run set (legacy healthy-orphan
+    /// sweep). Without --all, the default reap runs owner-known: it passes the
+    /// journal's live run ids so healthy nodes of terminal/gone workflows are
+    /// reaped too (subject to the plugin's age grace).
     #[arg(long)]
     pub(crate) all: bool,
     /// Confirm reaping healthy orphans; required with --all (guards against a

--- a/crates/orchestrator-cli/src/services/operations/ops_environment.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_environment.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use anyhow::Result;
-use orchestrator_core::{EnvironmentClient, EnvironmentNode};
+use anyhow::{Context, Result};
+use orchestrator_core::{EnvironmentClient, EnvironmentNode, FileServiceHub, OrchestratorWorkflow, ServiceHub};
 use serde::Serialize;
 
 use crate::{print_value, EnvironmentCommand};
@@ -34,6 +34,50 @@ pub(crate) struct EnvironmentReapView {
 
 fn resolve_environment_client(project_root: &str, environment: Option<&str>) -> Result<EnvironmentClient> {
     EnvironmentClient::resolve(Path::new(project_root), environment.unwrap_or(""))
+}
+
+/// Bridge an async future into a sync call (the environment ops are sync but the
+/// hub's workflow service is async). Mirrors `environment_client::run_blocking`.
+fn run_blocking<F: std::future::Future>(fut: F) -> Result<F::Output> {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => Ok(tokio::task::block_in_place(|| handle.block_on(fut))),
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("building tokio runtime for journal liveness read")?;
+            Ok(rt.block_on(fut))
+        }
+    }
+}
+
+/// The journal's live (Pending/Running/Paused) run ids, for the reap plugin's
+/// owner-known mode. `Some` ONLY when the journal read succeeded — on ANY error
+/// returns `None` so the plugin keeps its dead-only default instead of reaping
+/// healthy nodes against a possibly-incomplete liveness set. An EMPTY vec is a
+/// trustworthy "no live runs" signal and is passed through on purpose.
+fn live_run_ids_from_journal(workflows: Result<Vec<OrchestratorWorkflow>>) -> Option<Vec<String>> {
+    match workflows {
+        Ok(workflows) => Some(workflows.into_iter().map(|workflow| workflow.id).collect()),
+        Err(error) => {
+            tracing::warn!(error = %error, "failed to read live workflow ids for environment reap; falling back to dead-only reap");
+            None
+        }
+    }
+}
+
+/// Build a hub for `project_root` and read the live run-id set. Both hub
+/// construction and the journal read fall back to `None` on error.
+fn live_run_ids_for_project(project_root: &str) -> Option<Vec<String>> {
+    let hub = match FileServiceHub::new(project_root) {
+        Ok(hub) => hub,
+        Err(error) => {
+            tracing::warn!(error = %error, "failed to open service hub for environment reap liveness; falling back to dead-only reap");
+            return None;
+        }
+    };
+    let workflows = run_blocking(async { hub.workflows().list_active().await }).and_then(|result| result);
+    live_run_ids_from_journal(workflows)
 }
 
 pub(crate) fn environment_list_application(
@@ -71,7 +115,14 @@ pub(crate) fn environment_reap_application(
     older_than_secs: Option<u64>,
 ) -> Result<EnvironmentReapView> {
     let client = resolve_environment_client(project_root, environment)?;
-    let report = client.reap(all, force, dry_run, older_than_secs)?;
+    // Owner-known mode (TASK-1466): the DEFAULT reap (no --all) hands the
+    // plugin the journal's live run-id set so it can also reap healthy (SUCCESS)
+    // nodes whose owning workflow is terminal. With --all we preserve the
+    // existing force-guarded healthy-orphan semantics exactly (no liveness set).
+    // Dry-run gets the same ids so the preview matches the real reap. Any
+    // journal-read failure yields `None` (dead-only reap), never `Some([])`.
+    let live_run_ids = if all { None } else { live_run_ids_for_project(project_root) };
+    let report = client.reap(all, force, dry_run, older_than_secs, live_run_ids)?;
     Ok(EnvironmentReapView {
         environment: client.plugin_name().to_string(),
         deleted: report.deleted,
@@ -115,7 +166,10 @@ mod tests {
     use orchestrator_core::EnvironmentNode;
     use serde_json::Value;
 
-    use super::{EnvironmentGetView, EnvironmentListView, EnvironmentReapView, EnvironmentTeardownView};
+    use super::{
+        live_run_ids_for_project, live_run_ids_from_journal, EnvironmentGetView, EnvironmentListView,
+        EnvironmentReapView, EnvironmentTeardownView,
+    };
 
     fn node() -> EnvironmentNode {
         EnvironmentNode {
@@ -157,5 +211,100 @@ mod tests {
         .expect("serialize reap");
         assert_eq!(reap.get("dry_run").and_then(Value::as_bool), Some(true));
         assert_eq!(reap.pointer("/kept/0/name").and_then(Value::as_str), Some("animus-run-1"));
+    }
+
+    #[test]
+    fn live_run_ids_from_journal_falls_back_to_none_on_read_error() {
+        assert!(live_run_ids_from_journal(Err(anyhow::anyhow!("journal unavailable"))).is_none());
+        // An empty-but-successful read is a TRUSTWORTHY "no live runs" signal:
+        // it must stay Some([]) so owner-known mode can reap ownerless nodes.
+        assert_eq!(live_run_ids_from_journal(Ok(Vec::new())), Some(Vec::new()));
+    }
+
+    /// A hub that cannot even be constructed must degrade to `None` (dead-only
+    /// reap), never to owner-known mode with an empty liveness set.
+    #[test]
+    fn live_run_ids_for_project_returns_none_when_hub_unavailable() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        // A regular FILE as project root makes FileServiceHub::new fail.
+        let bogus_root = temp.path().join("not-a-dir");
+        std::fs::write(&bogus_root, "x").expect("bogus root file");
+        assert!(live_run_ids_for_project(bogus_root.to_string_lossy().as_ref()).is_none());
+    }
+
+    /// End-to-end over a real FileServiceHub: Pending/Running/Paused runs are in
+    /// the liveness set; terminal (Cancelled) runs are excluded. This is the
+    /// same id namespace the broker stamps into `spec.metadata.animus_run_id`
+    /// (the journal workflow id — see `ProcessManager::register_run`).
+    #[test]
+    fn live_run_ids_for_project_includes_active_and_excludes_terminal_workflows() {
+        use orchestrator_core::{FileServiceHub, Priority, ServiceHub, TaskCreateInput, TaskType, WorkflowRunInput};
+        use protocol::test_utils::EnvVarGuard;
+        use std::process::Command as ProcessCommand;
+        use tempfile::TempDir;
+
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
+        let init = ProcessCommand::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(temp.path())
+            .status()
+            .expect("git init should run");
+        assert!(init.success(), "git init should succeed");
+        let project_root = temp.path().to_string_lossy().to_string();
+        let hub = FileServiceHub::new(&project_root).expect("file service hub");
+        // v0.6: the kernel sources its base workflow config from a config_source
+        // plugin; in tests, stand in for it after the hub scaffolds .animus/.
+        let _config_source_seam =
+            orchestrator_config::workflow_config::config_source_client::install_yaml_config_source_base(temp.path());
+
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().expect("test runtime");
+        let (active_id, terminal_id) = rt.block_on(async {
+            let task = hub
+                .tasks()
+                .create(TaskCreateInput {
+                    title: "reap liveness active".to_string(),
+                    description: "owner-known reap liveness test".to_string(),
+                    task_type: Some(TaskType::Feature),
+                    priority: Some(Priority::Medium),
+                    created_by: Some("test".to_string()),
+                    tags: Vec::new(),
+                    linked_requirements: Vec::new(),
+                    linked_architecture_entities: Vec::new(),
+                })
+                .await
+                .expect("active task should be created");
+            let terminal_task = hub
+                .tasks()
+                .create(TaskCreateInput {
+                    title: "reap liveness terminal".to_string(),
+                    description: "owner-known reap liveness test".to_string(),
+                    task_type: Some(TaskType::Feature),
+                    priority: Some(Priority::Medium),
+                    created_by: Some("test".to_string()),
+                    tags: Vec::new(),
+                    linked_requirements: Vec::new(),
+                    linked_architecture_entities: Vec::new(),
+                })
+                .await
+                .expect("terminal task should be created");
+            let active = hub
+                .workflows()
+                .run(WorkflowRunInput::for_task(task.id.clone(), None), None)
+                .await
+                .expect("active workflow should start");
+            let terminal = hub
+                .workflows()
+                .run(WorkflowRunInput::for_task(terminal_task.id.clone(), None), None)
+                .await
+                .expect("terminal workflow should start");
+            hub.workflows().cancel(&terminal.id).await.expect("workflow should cancel");
+            (active.id, terminal.id)
+        });
+
+        let ids = live_run_ids_for_project(&project_root).expect("liveness read should succeed");
+        assert!(ids.contains(&active_id), "active run {active_id} must be protected, got {ids:?}");
+        assert!(!ids.contains(&terminal_id), "terminal run {terminal_id} must be excluded, got {ids:?}");
     }
 }

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/environment_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/environment_tools.rs
@@ -38,7 +38,10 @@ pub(super) struct EnvironmentTeardownInput {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub(super) struct EnvironmentReapInput {
-    /// Also reap non-dead nodes with no live owning run (requires `force`).
+    /// Also reap non-dead nodes with no live owning run (requires `force`),
+    /// WITHOUT consulting the journal's live run set. Without `all`, the
+    /// default reap runs owner-known: healthy nodes of terminal/gone workflows
+    /// are reaped too (subject to the plugin's age grace).
     #[serde(default)]
     pub(super) all: bool,
     /// Confirm reaping healthy orphans; required with `all`.
@@ -90,7 +93,7 @@ impl AoMcpServer {
 
     #[tool(
         name = "animus.environment.reap",
-        description = "Reap orphaned/dead environment nodes. Default reaps ONLY dead (FAILED/CRASHED) nodes — always safe. Purpose: clean up leaked run nodes without a dashboard/2FA delete. Prerequisites: an environment plugin installed. Example: {} (reap dead) or {\"dry_run\": true} (preview) or {\"all\": true, \"force\": true} (also reap healthy orphans). Sequencing: run with dry_run first to preview.",
+        description = "Reap orphaned/dead environment nodes. Default reaps dead (FAILED/CRASHED) nodes AND, when the journal's live run set is readable, healthy (SUCCESS) nodes whose owning workflow is terminal/gone (owner-known mode; plugin age grace applies) — always safe. Purpose: clean up leaked run nodes without a dashboard/2FA delete. Prerequisites: an environment plugin installed. Example: {} (default owner-known reap) or {\"dry_run\": true} (preview) or {\"all\": true, \"force\": true} (legacy healthy-orphan sweep). Sequencing: run with dry_run first to preview.",
         input_schema = ao_schema_for_type::<EnvironmentReapInput>()
     )]
     async fn ao_environment_reap(&self, params: Parameters<EnvironmentReapInput>) -> Result<CallToolResult, McpError> {

--- a/crates/orchestrator-core/src/workflow/environment_client.rs
+++ b/crates/orchestrator-core/src/workflow/environment_client.rs
@@ -312,9 +312,21 @@ impl EnvironmentClient {
 
     /// `environment/reap`: destroy orphaned/dead managed nodes. Default (all=
     /// false) reaps only dead nodes; `all`+`force` also reaps healthy orphans;
-    /// `dry_run` reports the plan without deleting.
-    pub fn reap(&self, all: bool, force: bool, dry_run: bool, older_than_secs: Option<u64>) -> Result<ReapResponse> {
-        let request = ReapRequest { all, force, dry_run, older_than_secs };
+    /// `dry_run` reports the plan without deleting. When `live_run_ids` is
+    /// `Some`, the plugin switches to owner-known mode: healthy (SUCCESS) nodes
+    /// whose owning run id is NOT in the set are reaped (subject to the plugin's
+    /// age grace), and nodes owned by runs in the set are always kept. `None`
+    /// preserves the plugin's dead-only default — callers must pass `None`
+    /// (never `Some([])`) when they cannot obtain a trustworthy liveness set.
+    pub fn reap(
+        &self,
+        all: bool,
+        force: bool,
+        dry_run: bool,
+        older_than_secs: Option<u64>,
+        live_run_ids: Option<Vec<String>>,
+    ) -> Result<ReapResponse> {
+        let request = ReapRequest { all, force, dry_run, older_than_secs, live_run_ids };
         let value = self.call_blocking(METHOD_ENVIRONMENT_REAP, request, ENVIRONMENT_RPC_TIMEOUT)?;
         serde_json::from_value(value)
             .with_context(|| format!("decoding ReapResponse from environment plugin {}", self.plugin.name))

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ if you are upgrading from an earlier v0.4.x.
 
 Use the installer published from `launchapp-dev/animus-cli`:
 
-Current workspace CLI version: **v0.7.0-rc.40**.
+Current workspace CLI version: **v0.7.0-rc.42**.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
@@ -28,7 +28,7 @@ Options:
 
 ```bash
 # Install a specific release
-ANIMUS_VERSION=v0.7.0-rc.40 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
+ANIMUS_VERSION=v0.7.0-rc.42 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
 
 # Install into a custom directory
 ANIMUS_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -278,8 +278,14 @@ spawns a child Animus process.
 { "id": "animus-run-abc123" }                        // animus.environment.get
 { "id": "animus-run-abc123" }                        // animus.environment.teardown
 { "dry_run": true, "older_than_secs": 3600 }         // animus.environment.reap preview
-{ "all": true, "force": true }                       // also reap healthy orphans
+{ "all": true, "force": true }                       // legacy healthy-orphan sweep (no journal liveness)
 ```
+
+The default `reap` is owner-known: it passes the journal's live
+(Pending/Running/Paused) run ids to the plugin, which also reaps healthy
+nodes whose owning workflow is terminal/gone (age grace applies; live owners
+are always kept). If the journal is unreadable it falls back to reaping only
+dead nodes.
 
 These tools remain management-only until the environment node-management
 protocol carries an authenticated actor and the owning plugin enforces its

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -15,7 +15,7 @@ time so the container boots without network access.
 ```dockerfile
 # ---- stage 1: fetch the prebuilt animus binary ----
 FROM debian:bookworm-slim AS animus-fetch
-ARG ANIMUS_VERSION=v0.7.0-rc.40
+ARG ANIMUS_VERSION=v0.7.0-rc.42
 ARG ANIMUS_TARGET=x86_64-unknown-linux-gnu
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -82,7 +82,7 @@ CMD ["/app/deploy/start.sh"]
 
 | ARG | Default | Description |
 |---|---|---|
-| `ANIMUS_VERSION` | `v0.7.0-rc.40` | Release tag to download from `launchapp-dev/animus-cli` |
+| `ANIMUS_VERSION` | `v0.7.0-rc.42` | Release tag to download from `launchapp-dev/animus-cli` |
 | `ANIMUS_TARGET` | `x86_64-unknown-linux-gnu` | Target triple; must match the container's glibc |
 | `SIG` | `--signature-policy=disabled` | Signature policy flag passed to every `plugin install` |
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -365,7 +365,7 @@ animus
 │   ├── list                 List managed environment nodes with their state + orphan flag
 │   ├── get                  Describe one managed node by substrate id or name
 │   ├── teardown             Destroy one managed node by substrate id or name (idempotent)
-│   └── reap                 Reap orphaned/dead nodes (`--dry-run` previews; `--all --force` also reaps healthy orphans)
+│   └── reap                 Reap orphaned/dead nodes (default is owner-known: dead nodes + healthy nodes of terminal/gone workflows, `--dry-run` previews; `--all --force` keeps the legacy healthy-orphan sweep)
 │
 ├── flavor                   Inspect or install Animus flavor manifests (`flavors/<name>.toml`) — v0.5
 │   ├── list                 List available flavor manifests on disk

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -234,16 +234,20 @@ verbs to MCP callers through the same typed in-process application services used
 by the CLI. Those services drive the installed `environment` plugin's typed
 node-management protocol (`environment/list` · `/get` · `/teardown_node` ·
 `/reap`), so the plugin remains the intentional out-of-process state owner while
-the redundant child-CLI/argv hop is removed. `reap` defaults to deleting only
-DEAD (FAILED/CRASHED) nodes — always safe, since a live node is never dead;
-`all`+`force` also reaps healthy orphans.
+the redundant child-CLI/argv hop is removed. `reap` defaults to owner-known
+mode: it deletes DEAD (FAILED/CRASHED) nodes and, when the journal's live run
+set is readable, also healthy (SUCCESS) nodes whose owning workflow is
+terminal/gone (the plugin still applies its age grace; nodes owned by live
+runs are always kept). If the journal read fails, reap falls back to deleting
+only dead nodes. `all`+`force` keeps the legacy healthy-orphan sweep without
+consulting the journal.
 
 | Tool | Description | Key Parameters |
 |---|---|---|
 | `animus.environment.list` | List managed environment nodes with their state + orphan flag | `environment`, `project_root` |
 | `animus.environment.get` | Describe one managed node by substrate id or name | `id`, `environment`, `project_root` |
 | `animus.environment.teardown` | Destroy one managed node by substrate id or name (idempotent) | `id`, `environment`, `project_root` |
-| `animus.environment.reap` | Reap orphaned/dead nodes (default: only dead) | `all`, `force`, `dry_run`, `older_than_secs`, `environment`, `project_root` |
+| `animus.environment.reap` | Reap orphaned/dead nodes (default: owner-known — dead nodes + healthy nodes of terminal/gone workflows) | `all`, `force`, `dry_run`, `older_than_secs`, `environment`, `project_root` |
 
 Environment tools remain management-only because the node-management protocol
 does not carry an authenticated actor or partition nodes by user and tenant.


### PR DESCRIPTION
## Root cause

The Railway environment plugin already implements **owner-known reap**: when `environment/reap` carries `live_run_ids`, healthy (SUCCESS) nodes whose owning run is NOT in that set are reaped without `--force` (300s age grace floor), while nodes owned by live runs are always kept. The CLI side was an **unwired seam** — `EnvironmentClient::reap` built a `ReapRequest` with no `live_run_ids`, so healthy zombie SUCCESS nodes of terminal/gone workflows survived every default `animus environment reap` and accumulated as leaked Railway services.

## What changed

- `crates/orchestrator-core/src/workflow/environment_client.rs`: `reap()` takes `live_run_ids: Option<Vec<String>>` and serializes it into `ReapRequest` (additive, serde-defaulted on the wire).
- `crates/orchestrator-cli/src/services/operations/ops_environment.rs`: the DEFAULT reap (no `--all`) computes the journal's live run-id set — `FileServiceHub` → `workflows().list_active()` (Pending/Running/Paused) — and passes `Some(ids)` so the plugin runs owner-known. `--dry-run` gets the same ids so the preview matches the real reap. `--all` passes `None`: the legacy force-guarded healthy-orphan sweep is byte-identical to today.
- MCP mirror (`animus.environment.reap`) inherits the same behavior — it calls the same typed application service; only its tool description/input docs changed.
- Docs updated: `docs/reference/cli/index.md`, `docs/reference/mcp-tools.md`, `docs/guides/agents.md`.

## Run-id namespace evidence

The ids sent are journal workflow ids, the SAME namespace the broker hands the env plugin: `ProcessManager` registers `run_id = target_workflow_id` (crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs:648-657) and the broker stamps it into `spec.metadata.animus_run_id` (`set_run_id_metadata`, environment_broker.rs:437 + :1097) — exactly what the plugin matches against. Delegated/resumable runs stay protected because their rows are Pending/Running/Paused and therefore in the set.

## Safety analysis

- Any hub-construction or journal-read failure → `None` (today's dead-only default), logged at warn. We NEVER send `Some([])` off a failed read — a provided-but-empty set would let the plugin reap ALL healthy nodes older than 300s.
- An empty set from a SUCCESSFUL read genuinely means "no live runs" and is passed through on purpose — that is the zombie-cleanup case this task exists for.
- `--all --force` behavior is unchanged (no liveness set sent).

## ⚠️ Release gate — DO NOT merge/release as-is

`animus-environment-protocol` is temporarily pinned to the **branch** `task-1466/reap-live-run-ids` (animus-protocol PR https://github.com/launchapp-dev/animus-protocol/pull/8, head 21f623c) because the family pin `v0.7.0-rc.14` predates the field. Before merge/release the parent must:

1. Merge animus-protocol PR #8.
2. Cut a new write-once protocol tag on the merge commit.
3. Repin `animus-environment-protocol` here from `branch` to that `tag` (the Cargo.toml comment marks the spot), and refresh Cargo.lock.

Pin diff summary: only the `animus-environment-protocol` subtree moved — Cargo.lock gains second copies of `animus-execution-protocol`/`animus-plugin-protocol` from the branch commit (its in-repo path deps); every other protocol crate still resolves from `tag=v0.7.0-rc.14`.

## Tests

- New in `ops_environment.rs`:
  - `live_run_ids_from_journal_falls_back_to_none_on_read_error` (error → `None`; empty Ok → `Some([])`)
  - `live_run_ids_for_project_returns_none_when_hub_unavailable` (hub construction failure → `None`)
  - `live_run_ids_for_project_includes_active_and_excludes_terminal_workflows` (real FileServiceHub over a tempfile git repo; active run protected, cancelled run excluded)
- `cargo test -p orchestrator-cli environment`: 36 passed, 0 failed
- `cargo test -p orchestrator-core`: 447 passed, 0 failed
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean
- `cargo check --locked --all-targets --workspace`: clean
