### PR TITLE
fix(daemon): tear down terminal-run environment leases orphaned by owner death (TASK-1466)

### DIFF
--- a/crates/animus-runtime-shared/src/phase_session.rs
+++ b/crates/animus-runtime-shared/src/phase_session.rs
@@ -270,48 +270,11 @@ pub fn read_path(path: &Path) -> io::Result<Option<SessionCheckpoint>> {
     }
 }
 
-pub fn list_running_checkpoints(scoped_root: &Path) -> io::Result<Vec<(PathBuf, SessionCheckpoint)>> {
+/// Walk EVERY session checkpoint under the scoped runs root, regardless of
+/// status. Shared by the status-filtered list helpers below.
+fn walk_session_checkpoints(scoped_root: &Path) -> io::Result<Vec<(PathBuf, SessionCheckpoint)>> {
     let runs_dir = scoped_root.join("runs");
     let mut out = Vec::new();
-    let entries = match fs::read_dir(&runs_dir) {
-        Ok(e) => e,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(err) => return Err(err),
-    };
-    for run_entry in entries {
-        let run_entry = run_entry?;
-        let phases_dir = run_entry.path().join("phases");
-        let phase_entries = match fs::read_dir(&phases_dir) {
-            Ok(e) => e,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
-            Err(err) => return Err(err),
-        };
-        for phase_entry in phase_entries {
-            let phase_entry = phase_entry?;
-            let path = phase_entry.path();
-            if !path.file_name().and_then(|n| n.to_str()).is_some_and(|n| n.ends_with(".session.json")) {
-                continue;
-            }
-            if let Some(checkpoint) = read_path(&path)? {
-                if matches!(checkpoint.status, SessionCheckpointStatus::Running) {
-                    out.push((path, checkpoint));
-                }
-            }
-        }
-    }
-    Ok(out)
-}
-
-/// Workflow ids that have at least one session checkpoint in `Blocked` state.
-///
-/// A `Blocked` checkpoint marks a mid-phase resume that was intentionally held
-/// (e.g. the provider plugin is not installed, or `resume_agent` returned a
-/// failure) and is waiting on an operator `animus workflow resume --force`. The
-/// daemon's journal-resume re-dispatch consults this so it does NOT spawn a
-/// fresh runner for such a run and bypass the hold.
-pub fn blocked_checkpoint_workflow_ids(scoped_root: &Path) -> io::Result<std::collections::HashSet<String>> {
-    let runs_dir = scoped_root.join("runs");
-    let mut out = std::collections::HashSet::new();
     let entries = match fs::read_dir(&runs_dir) {
         Ok(e) => e,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(out),
@@ -332,13 +295,45 @@ pub fn blocked_checkpoint_workflow_ids(scoped_root: &Path) -> io::Result<std::co
                 continue;
             }
             if let Some(checkpoint) = read_path(&path)? {
-                if matches!(checkpoint.status, SessionCheckpointStatus::Blocked) {
-                    out.insert(checkpoint.workflow_id);
-                }
+                out.push((path, checkpoint));
             }
         }
     }
     Ok(out)
+}
+
+pub fn list_running_checkpoints(scoped_root: &Path) -> io::Result<Vec<(PathBuf, SessionCheckpoint)>> {
+    Ok(walk_session_checkpoints(scoped_root)?
+        .into_iter()
+        .filter(|(_, checkpoint)| matches!(checkpoint.status, SessionCheckpointStatus::Running))
+        .collect())
+}
+
+/// TASK-1466: every checkpoint (ANY status) carrying an environment binding
+/// that has NOT been torn down. The steady-state terminal-teardown sweep uses
+/// this to find nodes whose owning runner/plugin died before teardown: unlike
+/// [`list_running_checkpoints`], a terminal phase (Completed/Failed) whose
+/// teardown never ran must still surface here.
+pub fn list_checkpoints_with_retained_environment(scoped_root: &Path) -> io::Result<Vec<(PathBuf, SessionCheckpoint)>> {
+    Ok(walk_session_checkpoints(scoped_root)?
+        .into_iter()
+        .filter(|(_, checkpoint)| checkpoint.environment.as_ref().is_some_and(|binding| !binding.torn_down))
+        .collect())
+}
+
+/// Workflow ids that have at least one session checkpoint in `Blocked` state.
+///
+/// A `Blocked` checkpoint marks a mid-phase resume that was intentionally held
+/// (e.g. the provider plugin is not installed, or `resume_agent` returned a
+/// failure) and is waiting on an operator `animus workflow resume --force`. The
+/// daemon's journal-resume re-dispatch consults this so it does NOT spawn a
+/// fresh runner for such a run and bypass the hold.
+pub fn blocked_checkpoint_workflow_ids(scoped_root: &Path) -> io::Result<std::collections::HashSet<String>> {
+    Ok(walk_session_checkpoints(scoped_root)?
+        .into_iter()
+        .filter(|(_, checkpoint)| matches!(checkpoint.status, SessionCheckpointStatus::Blocked))
+        .map(|(_, checkpoint)| checkpoint.workflow_id)
+        .collect())
 }
 
 fn mutate(
@@ -636,5 +631,36 @@ mod tests {
             serde_json::from_value(legacy).expect("legacy checkpoint without `environment` must deserialize");
         assert!(cp.environment.is_none(), "missing environment field defaults to None");
         assert_eq!(cp.status, SessionCheckpointStatus::Running);
+    }
+
+    // TASK-1466: the terminal-teardown sweep enumerates retained bindings
+    // across ALL checkpoint statuses (a Failed/Completed checkpoint whose
+    // teardown never ran must still surface), and stops surfacing a binding
+    // once it is marked torn down.
+    #[test]
+    fn retained_environment_listing_covers_terminal_checkpoints_until_marked() {
+        let temp = tempdir().expect("tempdir");
+        let scoped_root = temp.path();
+        write_session_pending(scoped_root, "wf-env-5", "phase-a", "claude", "run-5", None).expect("pending");
+        update_session_environment(scoped_root, "wf-env-5", "phase-a", sample_binding()).expect("persist binding");
+        update_session_failed(scoped_root, "wf-env-5", "phase-a", "owner died before teardown")
+            .expect("fail checkpoint");
+
+        // A Failed (non-Running) checkpoint with an untorn binding is exactly
+        // the leak the sweep exists for; list_running_checkpoints hides it.
+        assert!(
+            list_running_checkpoints(scoped_root).expect("running list").is_empty(),
+            "a failed checkpoint is not Running"
+        );
+        let retained = list_checkpoints_with_retained_environment(scoped_root).expect("retained list");
+        assert_eq!(retained.len(), 1, "the untorn terminal binding must surface for the sweep");
+        assert_eq!(retained[0].1.workflow_id, "wf-env-5");
+        assert_eq!(retained[0].1.phase_id, "phase-a");
+
+        mark_environment_torn_down(scoped_root, "wf-env-5", "phase-a").expect("mark torn down");
+        assert!(
+            list_checkpoints_with_retained_environment(scoped_root).expect("retained list").is_empty(),
+            "a torn-down binding no longer surfaces"
+        );
     }
 }

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_reconciliation.rs
@@ -1,9 +1,10 @@
 use super::*;
 use crate::services::runtime::execution_fact_projection::project_terminal_workflow_result;
 use crate::services::runtime::workflow_mutation_surface::cancel_orphaned_running_workflow;
-use animus_environment_protocol::{ExecResponse, HarnessCommand};
+use animus_environment_protocol::{EnvironmentHandle, ExecResponse, HarnessCommand};
 use animus_runtime_shared::phase_session::{
-    mark_environment_torn_down, read_checkpoint, update_session_failed, EnvironmentBinding,
+    list_checkpoints_with_retained_environment, mark_environment_torn_down, read_checkpoint, update_session_failed,
+    EnvironmentBinding,
 };
 use anyhow::{Context, Result};
 use orchestrator_core::{
@@ -83,6 +84,23 @@ enum ReconcileDecision {
     NotResumable,
     /// Cancelled as an unrecoverable orphan (cancel leg only).
     CancelledOrphan,
+    /// TASK-1466: a TERMINAL run's retained environment lease was torn down
+    /// by the sweep (terminal-env leg only).
+    TeardownTerminalLease,
+    /// TASK-1466: teardown of a terminal run's retained environment lease
+    /// FAILED; the durable record is retained for the next sweep
+    /// (terminal-env leg only).
+    TerminalLeaseTeardownFailed,
+    /// TASK-1466: retained lease skipped — the run is not terminal in the
+    /// journal (terminal-env leg only).
+    SkippedLeaseRunActive,
+    /// TASK-1466: retained lease skipped — the journal row could not be read,
+    /// so terminality is unconfirmed (terminal-env leg only; fail safe).
+    SkippedLeaseRunUnknown,
+    /// TASK-1466: terminal run is still inside the teardown grace floor, so
+    /// the normal owner-driven teardown gets first chance (terminal-env leg
+    /// only).
+    TerminalLeaseWithinGrace,
 }
 
 impl ReconcileDecision {
@@ -101,6 +119,11 @@ impl ReconcileDecision {
             ReconcileDecision::SkippedBlockedResume => "skipped-blocked-resume",
             ReconcileDecision::NotResumable => "not-resumable",
             ReconcileDecision::CancelledOrphan => "cancelled-orphan",
+            ReconcileDecision::TeardownTerminalLease => "teardown-terminal-lease",
+            ReconcileDecision::TerminalLeaseTeardownFailed => "terminal-lease-teardown-failed",
+            ReconcileDecision::SkippedLeaseRunActive => "skipped-lease-run-active",
+            ReconcileDecision::SkippedLeaseRunUnknown => "skipped-lease-run-unknown",
+            ReconcileDecision::TerminalLeaseWithinGrace => "terminal-lease-within-grace",
         }
     }
 
@@ -113,6 +136,8 @@ impl ReconcileDecision {
                 | ReconcileDecision::SkippedDelegated
                 | ReconcileDecision::TerminalizeDeadDelegate
                 | ReconcileDecision::RedispatchCandidate
+                | ReconcileDecision::TeardownTerminalLease
+                | ReconcileDecision::TerminalLeaseTeardownFailed
         )
     }
 }
@@ -907,12 +932,18 @@ pub async fn recover_orphaned_running_workflows(
             ReconcileDecision::MergeConflict
             | ReconcileDecision::WaitingManual
             | ReconcileDecision::WithinGrace
-            // These variants never arise on the cancel leg (redispatch-only), but
-            // are matched exhaustively; they are no-ops here.
+            // These variants never arise on the cancel leg (redispatch- and
+            // terminal-env-only), but are matched exhaustively; they are no-ops
+            // here.
             | ReconcileDecision::RedispatchCandidate
             | ReconcileDecision::SkippedLiveOrphan
             | ReconcileDecision::SkippedBlockedResume
-            | ReconcileDecision::NotResumable => {}
+            | ReconcileDecision::NotResumable
+            | ReconcileDecision::TeardownTerminalLease
+            | ReconcileDecision::TerminalLeaseTeardownFailed
+            | ReconcileDecision::SkippedLeaseRunActive
+            | ReconcileDecision::SkippedLeaseRunUnknown
+            | ReconcileDecision::TerminalLeaseWithinGrace => {}
             ReconcileDecision::PreservedResumable => {
                 // BU-4: with the durable journal active (kill-switch off), do NOT
                 // destroy resumable in-flight work on daemon restart/redeploy.
@@ -1222,7 +1253,8 @@ pub(crate) async fn resumable_orphans_for_redispatch(
             // All other outcomes exclude the run from re-dispatch (no-op). A
             // dead delegate normally gets terminalized by the cancel leg first,
             // but this leg independently applies the same gate so callers
-            // cannot re-dispatch-and-leak when invoked on its own.
+            // cannot re-dispatch-and-leak when invoked on its own. The
+            // terminal-env-only variants never arise here either.
             ReconcileDecision::MergeConflict
             | ReconcileDecision::WaitingManual
             | ReconcileDecision::SkippedLiveOrphan
@@ -1230,7 +1262,12 @@ pub(crate) async fn resumable_orphans_for_redispatch(
             | ReconcileDecision::WithinGrace
             | ReconcileDecision::NotResumable
             | ReconcileDecision::PreservedResumable
-            | ReconcileDecision::CancelledOrphan => {}
+            | ReconcileDecision::CancelledOrphan
+            | ReconcileDecision::TeardownTerminalLease
+            | ReconcileDecision::TerminalLeaseTeardownFailed
+            | ReconcileDecision::SkippedLeaseRunActive
+            | ReconcileDecision::SkippedLeaseRunUnknown
+            | ReconcileDecision::TerminalLeaseWithinGrace => {}
         }
     }
     emit_reconcile_sweep_summary(
@@ -1341,6 +1378,305 @@ pub async fn reconcile_manual_phase_timeouts(hub: Arc<dyn ServiceHub>, project_r
     }
 
     Ok(reconciled)
+}
+
+// ---------------------------------------------------------------------------
+// TASK-1466: terminal-run environment teardown sweep.
+//
+// Node teardown on workflow completion is driven by the OWNING runner/plugin
+// (terminal projection -> `ProcessManager::teardown_environment_if_terminal`
+// -> `EnvironmentBroker::teardown`). When that owner DIES with the run — a
+// phase failure kills the runner, the plugin restarts, or the daemon dies
+// between terminal projection and teardown — nothing ever tears the node
+// down: the broker retries a failed teardown record only at daemon STARTUP
+// (`reap_prior_daemon_records`), so at steady state the node stays alive on
+// the provider and burns compute indefinitely.
+//
+// This leg closes the gap: enumerate every durable UNTORN-DOWN environment
+// lease (broker lease records AND phase-session checkpoint bindings), look up
+// the owning run in the journal, and when the row is TERMINAL drive teardown
+// through the environment plugin exactly as the runner would have
+// (`EnvironmentClient::resolve` + `client.teardown(&handle)` — the plugin's
+// pre-teardown cleanup/publish hook is preserved; no direct node deletion).
+// On teardown/plugin failure the durable record is left in place so the NEXT
+// sweep retries, and a `reconcile-decision` line carries the reason.
+//
+// Double-teardown safety: the leg acts ONLY on a journal-confirmed terminal
+// row, and only after [`TERMINAL_ENV_TEARDOWN_GRACE_SECS`] has elapsed since
+// `completed_at` — the normal owner-driven teardown fires synchronously as
+// the run lands terminal, so the floor keeps the sweep from doubling an
+// in-flight teardown. Past the floor a terminal run has no live owner left to
+// race. Teardown itself is dispose-by-id idempotent and the broker tolerates
+// torn-down leases, so a residual race is safe.
+// ---------------------------------------------------------------------------
+
+/// Grace after a run lands TERMINAL in the journal before this sweep drives
+/// teardown itself (see the block comment above).
+const TERMINAL_ENV_TEARDOWN_GRACE_SECS: i64 = 90;
+
+/// One untorn-down environment lease attributed to a workflow run, assembled
+/// from the durable broker lease records and/or the phase-session checkpoint
+/// bindings (deduplicated by exact handle).
+struct RetainedEnvironmentLease {
+    run_id: String,
+    environment_id: String,
+    handle: EnvironmentHandle,
+    /// Root the environment client resolves against (the broker record's own
+    /// `project_root`, or the sweep's root for checkpoint-only leases).
+    resolve_root: String,
+    /// Checkpoint phases referencing this exact handle (marked torn down
+    /// after a successful teardown).
+    phase_ids: Vec<String>,
+    /// Whether a durable broker lease record exists for this run (deleted
+    /// after a successful teardown).
+    broker_record: bool,
+    /// Where the lease was found, for the decision log.
+    source: &'static str,
+    /// Broker record state or checkpoint status, for the decision log.
+    record_state: String,
+    /// Best available lease timestamp (record `updated_at` / binding
+    /// `bound_at`); the grace-floor fallback when the terminal journal row
+    /// has no `completed_at`.
+    reference_ts: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+fn parse_rfc3339(ts: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(ts).map(|dt| dt.with_timezone(&chrono::Utc)).ok()
+}
+
+/// Enumerate every durable untorn-down environment lease: broker lease
+/// records in any non-`TornDown` state with a persisted handle, plus
+/// phase-session checkpoint bindings with `torn_down == false`. The two
+/// sources overlap (the broker binds the Running phase checkpoint at
+/// acquire); entries are merged by exact handle so one node is torn down
+/// once per sweep.
+fn retained_environment_leases(scoped_root: &Path, project_root: &str) -> Vec<RetainedEnvironmentLease> {
+    let mut leases: Vec<RetainedEnvironmentLease> = Vec::new();
+    for record in orchestrator_daemon_runtime::list_environment_lease_records(project_root) {
+        if matches!(record.state, orchestrator_daemon_runtime::BrokerLeaseState::TornDown) {
+            continue;
+        }
+        let Some(handle) = record.handle else { continue };
+        leases.push(RetainedEnvironmentLease {
+            run_id: record.run_id,
+            environment_id: record.environment_id,
+            handle,
+            resolve_root: record.project_root,
+            phase_ids: Vec::new(),
+            broker_record: true,
+            source: "broker-lease",
+            record_state: record.state.label().to_string(),
+            reference_ts: parse_rfc3339(&record.updated_at),
+        });
+    }
+    let checkpoints = match list_checkpoints_with_retained_environment(scoped_root) {
+        Ok(checkpoints) => checkpoints,
+        Err(error) => {
+            warn!(
+                actor = protocol::ACTOR_DAEMON,
+                %error,
+                "failed to list phase checkpoints for terminal environment teardown sweep; broker leases only this sweep"
+            );
+            Vec::new()
+        }
+    };
+    for (_, checkpoint) in checkpoints {
+        let Some(binding) = checkpoint.environment.filter(|binding| !binding.torn_down) else { continue };
+        if let Some(lease) = leases.iter_mut().find(|lease| {
+            lease.run_id == checkpoint.workflow_id
+                && lease.environment_id == binding.environment_id
+                && lease.handle == binding.handle
+        }) {
+            lease.phase_ids.push(checkpoint.phase_id);
+            lease.source = "broker-lease+phase-checkpoint";
+            continue;
+        }
+        leases.push(RetainedEnvironmentLease {
+            run_id: checkpoint.workflow_id,
+            environment_id: binding.environment_id,
+            handle: binding.handle,
+            resolve_root: project_root.to_string(),
+            phase_ids: vec![checkpoint.phase_id],
+            broker_record: false,
+            source: "phase-checkpoint",
+            record_state: format!("{:?}", checkpoint.status),
+            reference_ts: parse_rfc3339(&binding.bound_at),
+        });
+    }
+    leases
+}
+
+/// Emit one greppable single-line `reconcile-decision` record for the
+/// terminal-env sweep (same key=value shape as the other sweeps).
+fn emit_terminal_env_decision(
+    lease: &RetainedEnvironmentLease,
+    run_status: Option<WorkflowStatus>,
+    age_secs: i64,
+    decision: ReconcileDecision,
+    reason: &str,
+) {
+    let reason = reason.replace(['\n', '\r'], " ");
+    println!(
+        "reconcile-decision ts={ts} sweep=terminal-env workflow_id={workflow_id} run_status={run_status} \
+         source={source} record_state={record_state} environment_id={environment_id} handle_id={handle_id} \
+         age_secs={age_secs} decision={decision} reason={reason}",
+        ts = chrono::Utc::now().to_rfc3339(),
+        workflow_id = log_field(&lease.run_id),
+        run_status = run_status.map(|status| format!("{status:?}")).unwrap_or_else(|| "-".to_string()),
+        source = lease.source,
+        record_state = log_field(&lease.record_state),
+        environment_id = log_field(&lease.environment_id),
+        handle_id = log_field(&lease.handle.id),
+        decision = decision.label(),
+    );
+}
+
+/// TASK-1466: tear down environment leases whose owning workflow run is
+/// TERMINAL in the journal but was never torn down (owner died before
+/// teardown). Returns the number of leases torn down this sweep. See the
+/// block comment above for the model and safety arguments.
+pub async fn reconcile_terminal_environment_leases(hub: Arc<dyn ServiceHub>, project_root: &str) -> usize {
+    reconcile_terminal_environment_leases_with(hub, project_root, |resolve_root, environment_id, handle| {
+        let client = EnvironmentClient::resolve(Path::new(resolve_root), environment_id).with_context(|| {
+            format!("cannot resolve environment plugin '{environment_id}' to tear down retained node {}", handle.id)
+        })?;
+        client.teardown(handle).with_context(|| {
+            format!(
+                "failed to teardown retained node {handle_id} in environment '{environment_id}'",
+                handle_id = handle.id
+            )
+        })
+    })
+    .await
+}
+
+/// The sweep with the environment teardown call injected, so tests can drive
+/// it without an installed environment plugin (mirrors
+/// [`teardown_retained_environment_with`]).
+async fn reconcile_terminal_environment_leases_with<F>(
+    hub: Arc<dyn ServiceHub>,
+    project_root: &str,
+    teardown: F,
+) -> usize
+where
+    F: FnMut(&str, &str, &EnvironmentHandle) -> anyhow::Result<()>,
+{
+    let mut teardown = teardown;
+    let Some(scoped_root) = protocol::scoped_state_root(Path::new(project_root)) else {
+        return 0;
+    };
+    let candidates = retained_environment_leases(&scoped_root, project_root);
+    if candidates.is_empty() {
+        return 0;
+    }
+    let trace = reconcile_trace_enabled();
+    let now = chrono::Utc::now();
+    let mut torn_down = 0usize;
+    for lease in candidates {
+        let workflow = match hub.workflows().get(&lease.run_id).await {
+            Ok(workflow) => workflow,
+            Err(error) => {
+                // Fail safe: without a journal row terminality cannot be
+                // confirmed, so the lease stays a retryable obligation.
+                if trace {
+                    emit_terminal_env_decision(
+                        &lease,
+                        None,
+                        -1,
+                        ReconcileDecision::SkippedLeaseRunUnknown,
+                        &format!("workflow lookup failed: {error:#}"),
+                    );
+                }
+                continue;
+            }
+        };
+        if !orchestrator_core::is_terminal_workflow_run_status(workflow.status) {
+            // A live (or merely non-terminal) owner may still tear this lease
+            // down itself; never race it.
+            if trace {
+                emit_terminal_env_decision(
+                    &lease,
+                    Some(workflow.status),
+                    -1,
+                    ReconcileDecision::SkippedLeaseRunActive,
+                    "run is not terminal",
+                );
+            }
+            continue;
+        }
+        let terminal_at = workflow.completed_at.or(lease.reference_ts);
+        let age_secs = terminal_at.map(|ts| (now - ts).num_seconds()).unwrap_or(i64::MAX);
+        if age_secs < TERMINAL_ENV_TEARDOWN_GRACE_SECS {
+            // The normal owner-driven teardown fires as the run lands
+            // terminal; give it first chance before doubling it.
+            if trace {
+                emit_terminal_env_decision(
+                    &lease,
+                    Some(workflow.status),
+                    age_secs,
+                    ReconcileDecision::TerminalLeaseWithinGrace,
+                    "terminal run within teardown grace floor",
+                );
+            }
+            continue;
+        }
+        match teardown(&lease.resolve_root, &lease.environment_id, &lease.handle) {
+            Ok(()) => {
+                // Mark every checkpoint binding torn down FIRST; only when all
+                // marks landed is the broker record deleted, so a mark failure
+                // keeps a durable retry obligation (the retried teardown is
+                // idempotent).
+                let mut all_marked = true;
+                for phase_id in &lease.phase_ids {
+                    if let Err(error) = mark_environment_torn_down(&scoped_root, &lease.run_id, phase_id) {
+                        all_marked = false;
+                        warn!(
+                            actor = protocol::ACTOR_DAEMON,
+                            workflow_id = %lease.run_id,
+                            node = %lease.handle.id,
+                            %error,
+                            "node was torn down but its checkpoint could not be marked; idempotent teardown will retry"
+                        );
+                    }
+                }
+                if all_marked && lease.broker_record {
+                    orchestrator_daemon_runtime::remove_environment_lease_record(project_root, &lease.run_id);
+                }
+                info!(
+                    actor = protocol::ACTOR_DAEMON,
+                    workflow_id = %lease.run_id,
+                    node = %lease.handle.id,
+                    source = lease.source,
+                    "tore down terminal workflow's retained environment node (TASK-1466)"
+                );
+                emit_terminal_env_decision(
+                    &lease,
+                    Some(workflow.status),
+                    age_secs,
+                    ReconcileDecision::TeardownTerminalLease,
+                    "terminal run retained an untorn-down environment lease",
+                );
+                torn_down = torn_down.saturating_add(1);
+            }
+            Err(error) => {
+                warn!(
+                    actor = protocol::ACTOR_DAEMON,
+                    workflow_id = %lease.run_id,
+                    node = %lease.handle.id,
+                    %error,
+                    "terminal-run environment teardown failed; retaining the durable record for the next sweep"
+                );
+                emit_terminal_env_decision(
+                    &lease,
+                    Some(workflow.status),
+                    age_secs,
+                    ReconcileDecision::TerminalLeaseTeardownFailed,
+                    &format!("{error:#}"),
+                );
+            }
+        }
+    }
+    torn_down
 }
 
 #[cfg(test)]
@@ -2184,6 +2520,278 @@ mod tests {
             !checkpoint.environment.expect("binding").torn_down,
             "failed teardown must leave the durable hold available for retry"
         );
+    }
+
+    // -----------------------------------------------------------------
+    // TASK-1466: terminal-run environment teardown sweep
+    // -----------------------------------------------------------------
+
+    /// TASK-1466 fixture: the backdated fixture run moved to a terminal
+    /// status, with `completed_at` backdated past the teardown grace floor.
+    async fn terminal_workflow_fixture(
+        temp: &TempDir,
+        status: WorkflowStatus,
+    ) -> (Arc<dyn ServiceHub>, String, String, Box<dyn std::any::Any>) {
+        let (hub, project_root, workflow_id, guards) = backdated_running_workflow_fixture(temp).await;
+        let manager = WorkflowStateManager::new(temp.path());
+        let mut stored = manager.load(&workflow_id).expect("workflow should load");
+        stored.status = status;
+        stored.completed_at = Some(chrono::Utc::now() - chrono::Duration::hours(1));
+        manager.save(&stored).expect("terminal workflow should save");
+        (hub, project_root, workflow_id, guards)
+    }
+
+    /// Write a durable broker lease record for `workflow_id` exactly as the
+    /// broker persists it, without constructing a broker.
+    fn write_broker_lease_record(project_root: &str, workflow_id: &str, node_id: &str) -> std::path::PathBuf {
+        let scoped_root = protocol::scoped_state_root(std::path::Path::new(project_root)).expect("scope");
+        let records_dir = scoped_root.join("workflow-environments");
+        std::fs::create_dir_all(&records_dir).expect("records dir");
+        let path = records_dir.join(format!("{}.json", protocol::sanitize_identifier(workflow_id, "run")));
+        let old = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        let record = serde_json::json!({
+            "run_id": workflow_id,
+            "daemon_instance_id": "dead-daemon",
+            "environment_id": "animus-environment-railway",
+            "project_root": project_root,
+            "state": "tearing-down",
+            "handle": { "id": node_id, "workspace_root": "/work", "metadata": { "railway_service_id": "svc-1" } },
+            "created_at": old,
+            "updated_at": old,
+        });
+        std::fs::write(&path, serde_json::to_vec_pretty(&record).expect("record json")).expect("write record");
+        path
+    }
+
+    // Core: a Completed run whose checkpoint binding was never torn down
+    // (owner died between terminal projection and teardown) gets torn down
+    // exactly once; a second sweep is inert.
+    #[tokio::test]
+    async fn terminal_completed_run_retained_binding_is_torn_down_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) =
+            terminal_workflow_fixture(&temp, WorkflowStatus::Completed).await;
+        let (scoped_root, phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-terminal")).await;
+        let teardown_calls = AtomicUsize::new(0);
+
+        let torn =
+            super::reconcile_terminal_environment_leases_with(hub.clone(), &project_root, |root, env, handle| {
+                assert_eq!(root, project_root.as_str());
+                assert_eq!(env, "animus-environment-railway");
+                assert_eq!(handle.id, "node-terminal");
+                teardown_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+            .await;
+        assert_eq!(torn, 1, "the terminal run's retained node must be torn down");
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 1);
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
+        assert!(checkpoint.environment.expect("binding").torn_down, "successful teardown marks the binding");
+
+        let torn_again = super::reconcile_terminal_environment_leases_with(hub.clone(), &project_root, |_, _, _| {
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await;
+        assert_eq!(torn_again, 0, "a torn-down lease is not re-torn-down");
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 1, "teardown ran exactly once across sweeps");
+    }
+
+    // A Failed run (phase failure killed the runner before teardown) gets the
+    // same treatment as Completed.
+    #[tokio::test]
+    async fn terminal_failed_run_retained_binding_is_torn_down() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = terminal_workflow_fixture(&temp, WorkflowStatus::Failed).await;
+        let (scoped_root, phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-failed")).await;
+        let teardown_calls = AtomicUsize::new(0);
+
+        let torn = super::reconcile_terminal_environment_leases_with(hub.clone(), &project_root, |_, _, handle| {
+            assert_eq!(handle.id, "node-failed");
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await;
+        assert_eq!(torn, 1, "a failed run's retained node must be torn down");
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
+        assert!(checkpoint.environment.expect("binding").torn_down);
+    }
+
+    // A NON-terminal run's retained lease is never touched: a live owner may
+    // still tear it down itself, and the sweep must not race it.
+    #[tokio::test]
+    async fn non_terminal_run_retained_binding_is_untouched() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) = backdated_running_workflow_fixture(&temp).await;
+        let (scoped_root, phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-live")).await;
+        let teardown_calls = AtomicUsize::new(0);
+
+        let torn = super::reconcile_terminal_environment_leases_with(hub.clone(), &project_root, |_, _, _| {
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await;
+        assert_eq!(torn, 0, "a Running run's lease is left to its live owner");
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 0, "teardown must not run for a Running row");
+
+        hub.workflows().pause(&workflow_id).await.expect("workflow should pause");
+        let torn = super::reconcile_terminal_environment_leases_with(hub.clone(), &project_root, |_, _, _| {
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await;
+        assert_eq!(torn, 0, "a Paused run's lease is left alone too");
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 0, "teardown must not run for a Paused row");
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
+        assert!(!checkpoint.environment.expect("binding").torn_down, "non-terminal binding stays retained");
+    }
+
+    // Retry semantics: a failed teardown keeps the durable obligation and the
+    // NEXT sweep drives teardown again (this is the steady-state retry the
+    // broker alone only performs at startup).
+    #[tokio::test]
+    async fn failed_teardown_is_retained_and_retried_next_sweep() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) =
+            terminal_workflow_fixture(&temp, WorkflowStatus::Completed).await;
+        let (scoped_root, phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-flaky")).await;
+        let teardown_calls = AtomicUsize::new(0);
+
+        let torn = super::reconcile_terminal_environment_leases_with(hub.clone(), &project_root, |_, _, _| {
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            anyhow::bail!("relay unavailable")
+        })
+        .await;
+        assert_eq!(torn, 0, "a failed teardown tears nothing down");
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
+        assert!(!checkpoint.environment.expect("binding").torn_down, "failure keeps the binding retryable");
+
+        let torn = super::reconcile_terminal_environment_leases_with(hub.clone(), &project_root, |_, _, _| {
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await;
+        assert_eq!(torn, 1, "the next sweep retries the retained lease");
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 2, "teardown was attempted once per sweep");
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
+        assert!(checkpoint.environment.expect("binding").torn_down, "the retry completes the cleanup");
+    }
+
+    // Broker lease records are swept too (a TearingDown record retained after
+    // a failed broker teardown, or a Ready record whose teardown never ran):
+    // torn down by handle and the durable record removed on success.
+    #[tokio::test]
+    async fn terminal_run_broker_lease_record_is_torn_down_and_removed() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) =
+            terminal_workflow_fixture(&temp, WorkflowStatus::Completed).await;
+        let record_path = write_broker_lease_record(&project_root, &workflow_id, "node-leased");
+        let teardown_calls = AtomicUsize::new(0);
+
+        let torn =
+            super::reconcile_terminal_environment_leases_with(hub.clone(), &project_root, |root, env, handle| {
+                assert_eq!(root, project_root.as_str());
+                assert_eq!(env, "animus-environment-railway");
+                assert_eq!(handle.id, "node-leased");
+                teardown_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+            .await;
+        assert_eq!(torn, 1, "the terminal run's broker lease must be torn down");
+        assert!(!record_path.exists(), "the durable lease record is removed after a successful teardown");
+
+        let torn_again = super::reconcile_terminal_environment_leases_with(hub.clone(), &project_root, |_, _, _| {
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await;
+        assert_eq!(torn_again, 0, "no record remains for the next sweep");
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 1, "teardown ran exactly once");
+    }
+
+    // When the SAME handle is held by both a broker record and a phase
+    // checkpoint, the sweep tears it down once and cleans up both records.
+    #[tokio::test]
+    async fn broker_record_and_checkpoint_for_one_handle_teardown_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) =
+            terminal_workflow_fixture(&temp, WorkflowStatus::Completed).await;
+        let (scoped_root, phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-shared")).await;
+        let record_path = write_broker_lease_record(&project_root, &workflow_id, "node-shared");
+        let teardown_calls = AtomicUsize::new(0);
+
+        let torn = super::reconcile_terminal_environment_leases_with(hub.clone(), &project_root, |_, _, handle| {
+            assert_eq!(handle.id, "node-shared");
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await;
+        assert_eq!(torn, 1, "one shared node is torn down once");
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 1, "no duplicate teardown for the same handle");
+        assert!(!record_path.exists(), "broker record removed");
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
+        assert!(checkpoint.environment.expect("binding").torn_down, "checkpoint binding marked");
+    }
+
+    // The grace floor: a run that JUST landed terminal is skipped so the
+    // normal owner-driven teardown (which fires as the journal lands
+    // terminal) gets first chance; the sweep is the backstop, not the racer.
+    #[tokio::test]
+    async fn terminal_run_within_teardown_grace_is_skipped() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _lock = test_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let temp = TempDir::new().expect("temp dir");
+        let (hub, project_root, workflow_id, _guards) =
+            terminal_workflow_fixture(&temp, WorkflowStatus::Completed).await;
+        let (scoped_root, phase_id) =
+            bind_delegate(&hub, &project_root, &workflow_id, sample_binding("node-fresh")).await;
+        // Re-terminalize with a FRESH completed_at (inside the grace floor).
+        let manager = WorkflowStateManager::new(temp.path());
+        let mut stored = manager.load(&workflow_id).expect("workflow should load");
+        stored.completed_at = Some(chrono::Utc::now());
+        manager.save(&stored).expect("workflow should save");
+        let teardown_calls = AtomicUsize::new(0);
+
+        let torn = super::reconcile_terminal_environment_leases_with(hub.clone(), &project_root, |_, _, _| {
+            teardown_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await;
+        assert_eq!(torn, 0, "a just-terminal run is left to the normal teardown path this sweep");
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 0);
+        let checkpoint =
+            read_checkpoint(&scoped_root, &workflow_id, &phase_id).expect("read").expect("checkpoint present");
+        assert!(!checkpoint.environment.expect("binding").torn_down, "the lease is retained for a later sweep");
     }
 }
 

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_run.rs
@@ -4,7 +4,7 @@ use crate::services::operations::{
 };
 use crate::services::runtime::runtime_daemon::build_daemon_ops_routing;
 use crate::services::runtime::runtime_daemon::daemon_reconciliation::{
-    journal_resume_enabled, recover_orphaned_running_workflows,
+    journal_resume_enabled, reconcile_terminal_environment_leases, recover_orphaned_running_workflows,
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -855,6 +855,16 @@ impl DaemonRunHooks for CliDaemonRunHost {
             let applier = FileResumedOutcomeApplier::new(project_root.to_string(), scoped_root.clone(), apply_hub);
             auto_resume_running_checkpoints(&scoped_root, &registry, &applier).await;
         }
+
+        // TASK-1466: a run can be TERMINAL in the durable journal while its
+        // environment teardown never ran (owner died between terminal
+        // projection and teardown, plugin restart, daemon kill). The broker's
+        // startup reap only handles records owned by a PRIOR daemon instance;
+        // sweep terminal rows with retained environment leases here too, and
+        // the heartbeat leg (`reconcile_terminal_environment_leases`) keeps
+        // retrying at steady state.
+        let terminal_env_hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(project_root)?);
+        reconcile_terminal_environment_leases(terminal_env_hub, project_root).await;
 
         Ok(orphans)
     }

--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_tick_executor.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::services::runtime::execution_fact_projection::reconcile_completed_processes;
 use crate::services::runtime::runtime_daemon::daemon_reconciliation::{
-    journal_resume_enabled, reconcile_manual_phase_timeouts, recover_orphaned_running_workflows,
-    resumable_orphans_for_redispatch,
+    journal_resume_enabled, reconcile_manual_phase_timeouts, reconcile_terminal_environment_leases,
+    recover_orphaned_running_workflows, resumable_orphans_for_redispatch,
 };
 use anyhow::{anyhow, Result};
 use orchestrator_core::services::ServiceHub;
@@ -309,6 +309,15 @@ impl DefaultProjectTickServices for CliProjectTickServices {
         // Steady-state: the remote delegate is alive on its node, so skip live
         // delegated runs (see `recover_orphaned_running_workflows`).
         Ok(recover_orphaned_running_workflows(hub, root, active_subject_ids, resume_orphans, true).await)
+    }
+
+    /// TASK-1466: steady-state sweep for environment leases whose workflow
+    /// run is TERMINAL in the journal but whose owning runner/plugin died
+    /// before teardown ran. Without this leg the broker only retries those
+    /// leases at daemon STARTUP, so a steady-state leak burns compute until
+    /// the next restart.
+    async fn reconcile_terminal_environment_leases(&mut self, hub: Arc<dyn ServiceHub>, root: &str) -> Result<usize> {
+        Ok(reconcile_terminal_environment_leases(hub, root).await)
     }
 
     async fn reconcile_manual_timeouts(&mut self, hub: Arc<dyn ServiceHub>, root: &str) -> Result<usize> {

--- a/crates/orchestrator-daemon-runtime/src/dispatch/environment_broker.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/environment_broker.rs
@@ -1170,6 +1170,112 @@ fn write_record_atomic(path: &Path, record: &LeaseRecord) -> std::io::Result<()>
     std::fs::rename(&tmp, path)
 }
 
+// ---------------------------------------------------------------------------
+// Durable lease-record read surface for steady-state reconciliation
+// (TASK-1466). The broker itself only retries a failed teardown at STARTUP
+// (`reap_prior_daemon_records`); the daemon's terminal-teardown sweep uses
+// these to find, at steady state, leases whose workflow is already TERMINAL
+// in the journal but whose owner died before teardown ran.
+// ---------------------------------------------------------------------------
+
+/// Persisted broker lease state as read by an outside reconciler. Mirrors the
+/// on-disk `LeaseState` (kept separate so the wire format stays private).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrokerLeaseState {
+    Preparing,
+    Ready,
+    TearingDown,
+    TornDown,
+    Failed,
+}
+
+impl BrokerLeaseState {
+    /// Stable kebab-case label for log lines (matches the on-disk serde form).
+    pub fn label(self) -> &'static str {
+        match self {
+            BrokerLeaseState::Preparing => "preparing",
+            BrokerLeaseState::Ready => "ready",
+            BrokerLeaseState::TearingDown => "tearing-down",
+            BrokerLeaseState::TornDown => "torn-down",
+            BrokerLeaseState::Failed => "failed",
+        }
+    }
+}
+
+impl From<LeaseState> for BrokerLeaseState {
+    fn from(state: LeaseState) -> Self {
+        match state {
+            LeaseState::Preparing => BrokerLeaseState::Preparing,
+            LeaseState::Ready => BrokerLeaseState::Ready,
+            LeaseState::TearingDown => BrokerLeaseState::TearingDown,
+            LeaseState::TornDown => BrokerLeaseState::TornDown,
+            LeaseState::Failed => BrokerLeaseState::Failed,
+        }
+    }
+}
+
+/// A durable broker lease record as persisted under the scoped
+/// `workflow-environments/` directory.
+#[derive(Debug, Clone)]
+pub struct EnvironmentLeaseSnapshot {
+    pub run_id: String,
+    pub environment_id: String,
+    pub project_root: String,
+    pub state: BrokerLeaseState,
+    pub handle: Option<EnvironmentHandle>,
+    pub updated_at: String,
+}
+
+/// The scoped (cross-restart) records directory, or `None` when the project
+/// has no scope. The per-pid `$TMPDIR` fallback in [`broker_records_dir`] is
+/// intentionally NOT consulted here: a dead daemon's pid-scoped dir is not
+/// discoverable, and this reader exists for cross-restart reconciliation.
+fn scoped_records_dir(project_root: &str) -> Option<PathBuf> {
+    protocol::scoped_state_root(Path::new(project_root)).map(|root| root.join("workflow-environments"))
+}
+
+/// Read every parseable durable lease record for `project_root`. Unparseable
+/// records are skipped (left in place for the broker's own startup reap,
+/// which deletes them).
+pub fn list_environment_lease_records(project_root: &str) -> Vec<EnvironmentLeaseSnapshot> {
+    let Some(records_dir) = scoped_records_dir(project_root) else {
+        return Vec::new();
+    };
+    let entries = match std::fs::read_dir(&records_dir) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                return None;
+            }
+            let record: LeaseRecord =
+                std::fs::read_to_string(&path).ok().and_then(|raw| serde_json::from_str(&raw).ok())?;
+            Some(EnvironmentLeaseSnapshot {
+                run_id: record.run_id,
+                environment_id: record.environment_id,
+                project_root: record.project_root,
+                state: BrokerLeaseState::from(record.state),
+                handle: record.handle,
+                updated_at: record.updated_at,
+            })
+        })
+        .collect()
+}
+
+/// Delete the durable lease record for `run_id` after a successful out-of-band
+/// teardown (the steady-state terminal-teardown sweep). Mirrors the broker's
+/// own `delete_record` path construction. Best-effort, like the broker's.
+pub fn remove_environment_lease_record(project_root: &str, run_id: &str) {
+    if let Some(records_dir) = scoped_records_dir(project_root) {
+        let _ =
+            std::fs::remove_file(records_dir.join(format!("{}.json", protocol::sanitize_identifier(run_id, "run"))));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1406,6 +1512,54 @@ mod tests {
             non_ready.state = state;
             assert!(!prior_record_is_claimed_for_resume(&non_ready, None), "{state:?} record was claimed");
         }
+    }
+
+    // TASK-1466: the steady-state terminal-teardown sweep reads durable lease
+    // records through the pub snapshot surface and removes them after a
+    // successful out-of-band teardown.
+    #[test]
+    fn lease_record_snapshots_list_and_remove() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_root = temp.path().to_string_lossy().into_owned();
+        let records_dir = protocol::repository_scope::scoped_state_root(temp.path())
+            .expect("scoped project state root")
+            .join("workflow-environments");
+        std::fs::create_dir_all(&records_dir).expect("records dir");
+        let handle = EnvironmentHandle {
+            id: "node-snap".to_string(),
+            workspace_root: "/workspace".to_string(),
+            metadata: json!({"relay": "opaque"}),
+        };
+        let record = LeaseRecord {
+            run_id: "wf-snap".to_string(),
+            daemon_instance_id: "dead-daemon".to_string(),
+            environment_id: "railway".to_string(),
+            project_root: project_root.clone(),
+            state: LeaseState::TearingDown,
+            handle: Some(handle.clone()),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:01Z".to_string(),
+        };
+        let path = records_dir.join(format!("{}.json", protocol::sanitize_identifier("wf-snap", "run")));
+        write_record_atomic(&path, &record).expect("write record");
+        // An unparseable sibling is skipped, not fatal.
+        std::fs::write(records_dir.join("garbage.json"), "not json").expect("write garbage");
+
+        let snapshots = list_environment_lease_records(&project_root);
+        assert_eq!(snapshots.len(), 1, "exactly the parseable record is returned");
+        let snapshot = &snapshots[0];
+        assert_eq!(snapshot.run_id, "wf-snap");
+        assert_eq!(snapshot.environment_id, "railway");
+        assert_eq!(snapshot.project_root, project_root);
+        assert_eq!(snapshot.state, BrokerLeaseState::TearingDown);
+        assert_eq!(snapshot.state.label(), "tearing-down");
+        assert_eq!(snapshot.handle.as_ref(), Some(&handle));
+        assert_eq!(snapshot.updated_at, "2026-01-01T00:00:01Z");
+
+        remove_environment_lease_record(&project_root, "wf-snap");
+        assert!(!path.exists(), "the durable record is deleted after teardown");
+        // Best-effort removal of an unknown run is a no-op.
+        remove_environment_lease_record(&project_root, "wf-unknown");
     }
 
     #[test]

--- a/crates/orchestrator-daemon-runtime/src/dispatch/mod.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/mod.rs
@@ -47,7 +47,8 @@ pub use dispatch_support::{
 pub use dispatch_workflow_start::DispatchWorkflowStart;
 pub use dispatch_workflow_start_summary::DispatchWorkflowStartSummary;
 pub use environment_broker::{
-    is_local_environment, EnvironmentBroker, ANIMUS_ENVIRONMENT_BROKER_ENVIRONMENT_ID_ENV,
+    is_local_environment, list_environment_lease_records, remove_environment_lease_record, BrokerLeaseState,
+    EnvironmentBroker, EnvironmentLeaseSnapshot, ANIMUS_ENVIRONMENT_BROKER_ENVIRONMENT_ID_ENV,
     ANIMUS_ENVIRONMENT_BROKER_RUN_ID_ENV, ANIMUS_ENVIRONMENT_BROKER_SOCKET_ENV, ANIMUS_ENVIRONMENT_BROKER_TOKEN_ENV,
 };
 #[cfg(unix)]

--- a/crates/orchestrator-daemon-runtime/src/lib.rs
+++ b/crates/orchestrator-daemon-runtime/src/lib.rs
@@ -27,11 +27,12 @@ pub use daemon::{
 pub use dispatch::{
     active_workflow_subject_ids, active_workflow_task_ids, build_completion_reconciliation_plan, build_runner_command,
     build_runner_command_from_dispatch, build_runner_command_with_resume, dispatch_capacity_for_options,
-    execute_dispatch_plan_via_runner, is_local_environment, is_terminally_completed_workflow, ready_dispatch_limit,
-    schedule_headroom, workflow_current_phase_id, CompletedProcess, CompletedProcessReconciliation,
+    execute_dispatch_plan_via_runner, is_local_environment, is_terminally_completed_workflow,
+    list_environment_lease_records, ready_dispatch_limit, remove_environment_lease_record, schedule_headroom,
+    workflow_current_phase_id, BrokerLeaseState, CompletedProcess, CompletedProcessReconciliation,
     CompletionReconciliationPlan, DispatchNotice, DispatchNoticeSink, DispatchSelectionSource, DispatchWorkflowStart,
-    DispatchWorkflowStartSummary, EnvironmentBroker, PlannedDispatchStart, ProcessManager, TickBudget,
-    WorkflowConcurrencyCapReached, WorkflowFailureEvent, ANIMUS_ENVIRONMENT_BROKER_ENVIRONMENT_ID_ENV,
+    DispatchWorkflowStartSummary, EnvironmentBroker, EnvironmentLeaseSnapshot, PlannedDispatchStart, ProcessManager,
+    TickBudget, WorkflowConcurrencyCapReached, WorkflowFailureEvent, ANIMUS_ENVIRONMENT_BROKER_ENVIRONMENT_ID_ENV,
     ANIMUS_ENVIRONMENT_BROKER_RUN_ID_ENV, ANIMUS_ENVIRONMENT_BROKER_SOCKET_ENV, ANIMUS_ENVIRONMENT_BROKER_TOKEN_ENV,
     ANIMUS_EXECUTION_FENCE_JSON_ENV,
 };

--- a/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/default_project_tick_driver.rs
@@ -49,6 +49,13 @@ pub trait DefaultProjectTickServices {
         Ok(0)
     }
 
+    /// TASK-1466: steady-state teardown of environment leases owned by
+    /// TERMINAL workflow runs whose teardown never ran. Default is a no-op;
+    /// the CLI tick services wire the reconciler in here.
+    async fn reconcile_terminal_environment_leases(&mut self, _hub: Arc<dyn ServiceHub>, _root: &str) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn reconcile_manual_timeouts(&mut self, _hub: Arc<dyn ServiceHub>, _root: &str) -> Result<usize> {
         Ok(0)
     }
@@ -319,6 +326,11 @@ where
         let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
         let active_subject_ids = self.process_manager.active_subject_ids();
         self.services.reconcile_zombie_workflows(hub, root, &active_subject_ids).await
+    }
+
+    async fn reconcile_terminal_environment_leases(&mut self, root: &str) -> Result<usize> {
+        let hub: Arc<dyn ServiceHub> = Arc::new(FileServiceHub::new(root)?);
+        self.services.reconcile_terminal_environment_leases(hub, root).await
     }
 
     async fn reconcile_manual_timeouts(&mut self, root: &str) -> Result<usize> {

--- a/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/project_tick_hooks.rs
@@ -43,6 +43,15 @@ pub trait ProjectTickHooks {
         Ok(0)
     }
 
+    /// TASK-1466: tear down environment leases whose workflow run is TERMINAL
+    /// in the journal but whose owner died before teardown ran (the broker
+    /// only retries those at startup otherwise). Housekeeping cadence, like
+    /// the other reconciliation legs. Returns the number of leases torn down
+    /// this sweep. Default is a no-op.
+    async fn reconcile_terminal_environment_leases(&mut self, _root: &str) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn reconcile_manual_timeouts(&mut self, _root: &str) -> Result<usize> {
         Ok(0)
     }

--- a/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
+++ b/crates/orchestrator-daemon-runtime/src/tick/run_project_tick.rs
@@ -55,12 +55,17 @@ where
     // Completed-process reaping always runs: it frees pool headroom that the
     // dispatch legs below depend on, so an event wake triggered by a workflow
     // completion can immediately dispatch follow-on work. The heavier
-    // reconciliation legs (manual timeouts, zombie workflows, stale
-    // in-progress tasks) are housekeeping: the daemon loop runs them on
-    // heartbeat cadence only (`mode.housekeeping`), never per-nudge.
+    // reconciliation legs (manual timeouts, zombie workflows, terminal
+    // environment teardown, stale in-progress tasks) are housekeeping: the
+    // daemon loop runs them on heartbeat cadence only (`mode.housekeeping`),
+    // never per-nudge.
     let reconciled_workflows = if mode.housekeeping { hooks.reconcile_manual_timeouts(root).await? } else { 0 };
     let completed_reconciliation = hooks.reconcile_completed_processes(root).await?;
     let reconciled_zombie_workflows = if mode.housekeeping { hooks.reconcile_zombie_workflows(root).await? } else { 0 };
+    // TASK-1466: steady-state retry of environment teardown for terminal runs
+    // whose owner died before teardown ran (startup-only retry otherwise).
+    let torn_down_terminal_environments =
+        if mode.housekeeping { hooks.reconcile_terminal_environment_leases(root).await? } else { 0 };
     if mode.housekeeping && args.reconcile_stale {
         hooks.reconcile_stale_in_progress_tasks(root, args.stale_threshold_hours).await?;
     }
@@ -69,7 +74,7 @@ where
     // not multiply cost scans.
     let budget_breaches = if mode.housekeeping { hooks.enforce_budget_caps(root).await? } else { Vec::new() };
     let mut execution_outcome = ProjectTickExecutionOutcome {
-        reconciled_workflows: reconciled_workflows + reconciled_zombie_workflows,
+        reconciled_workflows: reconciled_workflows + reconciled_zombie_workflows + torn_down_terminal_environments,
         executed_workflow_phases: completed_reconciliation.executed_workflow_phases,
         failed_workflow_phases: completed_reconciliation.failed_workflow_phases,
         workflow_failures: completed_reconciliation.workflow_failures,


### PR DESCRIPTION
## Root cause

Coding workflows run on ephemeral Railway run nodes. Node teardown on workflow completion is driven by the **owning** runner/plugin: terminal projection → `ProcessManager::teardown_environment_if_terminal` → `EnvironmentBroker::teardown`. When that owner **dies with the run** — a phase failure kills the runner, the env plugin restarts, or the daemon dies between terminal projection and teardown — nothing ever tears the node down. The broker retries a failed teardown record only at daemon **startup** (`reap_prior_daemon_records`); at steady state the terminal workflow's node stays SUCCESS-state on the provider and burns compute indefinitely.

## What changed

A new reconcile-sweep leg, `reconcile_terminal_environment_leases` in `daemon_reconciliation.rs`:

- **Candidates**: every durable untorn-down environment lease, from both record kinds —
  - broker lease records, via a new read-only pub surface on the broker (`list_environment_lease_records` / `remove_environment_lease_record` / `EnvironmentLeaseSnapshot` / `BrokerLeaseState` in `environment_broker.rs`, exported through `dispatch/mod.rs` + `lib.rs`);
  - phase-session checkpoint bindings, via the new `list_checkpoints_with_retained_environment` in `phase_session.rs` (unlike `list_running_checkpoints` it also sees terminal checkpoints — exactly the leak case). The existing checkpoint walkers now share one private walk; behavior unchanged.
  - the two sources are deduplicated by exact handle, so a node held by both is torn down once.
- **Gate**: `hub.workflows().get(run_id)` per candidate; the leg acts **only** when the journal row is TERMINAL (`Completed`/`Failed`/`Cancelled`/`Escalated`) and past a 90s `completed_at` grace floor. The normal owner-driven teardown fires synchronously as the run lands terminal, so the floor gives it first chance — the sweep is a backstop, not a racer. Teardown is dispose-by-id idempotent and the broker tolerates torn-down leases, so a residual race is safe. A row that can't be read fails safe (skip + retry next sweep).
- **Action**: `EnvironmentClient::resolve(root, environment_id)` + `client.teardown(&handle)` — the same call the runner would have made. On success, checkpoint bindings are marked torn down and the broker lease record is removed (record removal only after all marks land, so a mark failure keeps a retryable obligation).
- **Retry + logging**: on teardown/plugin failure the durable record is left in place so the **next** sweep retries — the steady-state retry the broker alone never performs. Note: there is no kernel-side "mark orphaned" API (the `orphan` flag is plugin-reported read state), so durable retention + sweep retry is the intended fallback when the plugin is unreachable. Every action emits a greppable `reconcile-decision ts=… sweep=terminal-env workflow_id=… run_status=… source=… record_state=… environment_id=… handle_id=… age_secs=… decision=… reason=…` line; `teardown-terminal-lease` and `terminal-lease-teardown-failed` always emit, skips (`skipped-lease-run-active`, `skipped-lease-run-unknown`, `terminal-lease-within-grace`) are trace-gated by the existing `ANIMUS_DAEMON_RECONCILE_TRACE`.

**Unpushed-work policy**: routing through `environment/teardown` (not delete) preserves the plugin's pre-teardown cleanup/publish hook. No direct node deletion is added anywhere.

**Wiring** (both call sites, matching the existing legs):
- startup: `recover_startup_orphans` in `daemon_run.rs` (after orphan recovery + auto-resume);
- heartbeat: new `reconcile_terminal_environment_leases` hook on `ProjectTickHooks` / `DefaultProjectTickServices` (default no-op, same shape as `enforce_budget_caps`), driven at housekeeping cadence by `run_project_tick.rs` and implemented by `CliProjectTickServices` in `daemon_tick_executor.rs`. The count folds into `reconciled_workflows` like the zombie/manual legs.

No CLI/MCP surface change, so no docs updates; no version bump (fix PRs don't bump — release commits do, e.g. TASK-1332).

## Tests

New regression coverage, all in the repo's existing style (real `FileServiceHub` over a tempfile git repo, config-source test seam, injectable teardown closure):

`daemon_reconciliation.rs` (6):
- terminal `Completed` run with retained checkpoint binding → teardown called exactly once, binding marked, second sweep inert;
- terminal `Failed` run → same;
- `Running` and `Paused` runs → untouched, teardown never called;
- teardown failure → binding retained, next sweep retries and completes;
- broker lease record (`tearing-down`, handle persisted) for a terminal run → torn down by handle, record file removed;
- broker record + checkpoint holding the **same** handle → single teardown, both records cleaned;
- terminal run inside the 90s grace floor → skipped.

`environment_broker.rs`: lease-record snapshot list/remove round-trip (unparseable siblings skipped).
`phase_session.rs`: retained-environment listing covers terminal checkpoints until marked torn down.

## Verification (local)

- `cargo test -p orchestrator-cli daemon_reconciliation` — 30 passed (24 existing + 6 new)
- `cargo test -p orchestrator-daemon-runtime` — all suites green (340 lib tests incl. the new broker test, all integration suites)
- `cargo test -p animus-runtime-shared phase_session` — 8 passed (incl. new)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo check --locked --all-targets --workspace` — clean
- `scripts/check-doc-sync.sh` — fails identically on the unmodified baseline (README still says rc.40 vs Cargo.toml rc.42); pre-existing drift, not from this change.

## Release implications

Kernel-side leg of the coordinated TASK-1466 fix, alongside animus-protocol PR https://github.com/launchapp-dev/animus-protocol/pull/8 (`live_run_ids` on `ReapRequest`) and the animus-environment-railway reaper PR. After merge: tag a new `v0.7.0-rc.N` release per the repo's release process, then the Portal runtime pins (`.animus/plugins.lock`, `animus.toml`, `runtime/release-components.v1.json`) pick it up in a coordinated runtime release; production proof requires a deployed canary showing a terminal run's node being torn down by the sweep after simulated owner death.