### PR TITLE
feat(output): log_storage read-back fallback for node-executed runs (TASK-1462)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 Open a fresh **Claude Code** (or **Codex** / **OpenCode** / **Cursor**) session and paste this. The agent installs the Animus CLI, clones `animus-skills`, runs the setup script, and adds the project section to `CLAUDE.md` / `AGENTS.md`. You'll be running workflows in about a minute.
 
-> Install Animus + Animus Skills: run **`curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash`** to install the `animus` CLI (currently `v0.7.0-rc.40` in this repo), then **`animus plugin install-defaults`** to pull in the provider + subject + workflow_runner + queue plugins the daemon needs (one-time setup, idempotent; add `--include-recommended` for the web UI and extra providers). Then **`git clone --single-branch --depth 1 https://github.com/launchapp-dev/animus-skills.git ~/.claude/skills/animus-skills && cd ~/.claude/skills/animus-skills && ./setup`** to link the skills and write `.mcp.json`. Add an "Animus" section to CLAUDE.md (or AGENTS.md for Codex) listing the slash commands: `/animus-setup`, `/animus-getting-started`, `/animus-mcp-setup`, `/animus-workflow-authoring`, `/animus-pack-authoring`, `/animus-skill-authoring`, `/animus-troubleshooting`. Restart the agent so the new `animus` MCP server is picked up. From a project root, run `animus init --walkthrough` to scaffold `.animus/`, install packs, and optionally start the daemon.
+> Install Animus + Animus Skills: run **`curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash`** to install the `animus` CLI (currently `v0.7.0-rc.42` in this repo), then **`animus plugin install-defaults`** to pull in the provider + subject + workflow_runner + queue plugins the daemon needs (one-time setup, idempotent; add `--include-recommended` for the web UI and extra providers). Then **`git clone --single-branch --depth 1 https://github.com/launchapp-dev/animus-skills.git ~/.claude/skills/animus-skills && cd ~/.claude/skills/animus-skills && ./setup`** to link the skills and write `.mcp.json`. Add an "Animus" section to CLAUDE.md (or AGENTS.md for Codex) listing the slash commands: `/animus-setup`, `/animus-getting-started`, `/animus-mcp-setup`, `/animus-workflow-authoring`, `/animus-pack-authoring`, `/animus-skill-authoring`, `/animus-troubleshooting`. Restart the agent so the new `animus` MCP server is picked up. From a project root, run `animus init --walkthrough` to scaffold `.animus/`, install packs, and optionally start the daemon.
 
 For Codex CLI, swap the clone path to `~/.codex/skills/animus-skills` and edit `AGENTS.md` instead of `CLAUDE.md`.
 
@@ -83,7 +83,7 @@ animus install --locked
 
 ```bash
 # Specific version
-ANIMUS_VERSION=v0.7.0-rc.40 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
+ANIMUS_VERSION=v0.7.0-rc.42 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
 
 # Custom directory
 ANIMUS_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash

--- a/crates/orchestrator-cli/src/services/operations.rs
+++ b/crates/orchestrator-cli/src/services/operations.rs
@@ -13,6 +13,7 @@ mod ops_manifest;
 mod ops_mcp;
 mod ops_metrics;
 mod ops_output;
+mod ops_output_remote;
 mod ops_pack;
 mod ops_plugin;
 mod ops_queue;

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/output_inproc.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/output_inproc.rs
@@ -30,10 +30,34 @@ impl AoMcpServer {
         }
     }
 
-    pub(super) fn output_run_inproc(&self, input: super::RunIdInput) -> CallToolResult {
-        self.run_output_application("animus.output.run", input.project_root, true, |root, actor| {
-            output_read_application(root, Some(&input.run_id), None, None, actor)
+    /// Async variant for output applications that may fall back to the
+    /// log_storage backend (remote/node-executed runs).
+    async fn run_output_application_async<T, F, Fut>(
+        &self,
+        tool_name: &str,
+        project_root: Option<String>,
+        actor_bound: bool,
+        call: F,
+    ) -> CallToolResult
+    where
+        T: Serialize,
+        F: FnOnce(String, Option<animus_actor::Actor>) -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        self.audit_actor_tool_decision(tool_name, actor_bound, if actor_bound { "forward" } else { "management-only" });
+        let project_root = resolve_project_root(&self.default_project_root, project_root);
+        let actor = self.pinned_actor().cloned();
+        match call(project_root, actor).await {
+            Ok(result) => CallToolResult::structured(json!({ "tool": tool_name, "result": result })),
+            Err(error) => CallToolResult::structured_error(build_inproc_tool_error_payload(tool_name, &error)),
+        }
+    }
+
+    pub(super) async fn output_run_inproc(&self, input: super::RunIdInput) -> CallToolResult {
+        self.run_output_application_async("animus.output.run", input.project_root, true, |root, actor| async move {
+            output_read_application(&root, Some(&input.run_id), None, None, actor.as_ref()).await
         })
+        .await
     }
 
     pub(super) fn output_phase_outputs_inproc(&self, input: super::OutputPhaseOutputsInput) -> CallToolResult {
@@ -42,16 +66,24 @@ impl AoMcpServer {
         })
     }
 
-    pub(super) fn output_monitor_inproc(&self, input: super::OutputMonitorInput) -> CallToolResult {
-        self.run_output_application("animus.output.monitor", input.project_root, false, |root, _actor| {
-            output_monitor_application(root, &input.run_id, input.task_id.as_deref(), input.phase_id.as_deref())
-        })
+    pub(super) async fn output_monitor_inproc(&self, input: super::OutputMonitorInput) -> CallToolResult {
+        self.run_output_application_async(
+            "animus.output.monitor",
+            input.project_root,
+            false,
+            |root, _actor| async move {
+                output_monitor_application(&root, &input.run_id, input.task_id.as_deref(), input.phase_id.as_deref())
+                    .await
+            },
+        )
+        .await
     }
 
-    pub(super) fn output_jsonl_inproc(&self, input: super::OutputJsonlInput) -> CallToolResult {
-        self.run_output_application("animus.output.jsonl", input.project_root, false, |root, _actor| {
-            output_jsonl_application(root, &input.run_id, input.entries)
+    pub(super) async fn output_jsonl_inproc(&self, input: super::OutputJsonlInput) -> CallToolResult {
+        self.run_output_application_async("animus.output.jsonl", input.project_root, false, |root, _actor| async move {
+            output_jsonl_application(&root, &input.run_id, input.entries).await
         })
+        .await
     }
 
     pub(super) fn output_artifacts_inproc(&self, input: super::ExecutionIdInput) -> CallToolResult {
@@ -67,8 +99,9 @@ mod tests {
     use protocol::RunId;
     use serde_json::Value;
 
-    #[test]
-    fn output_read_is_in_process_and_conceals_cross_actor_runs() {
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // intentional: guards process-global env mutation across the awaits
+    async fn output_read_is_in_process_and_conceals_cross_actor_runs() {
         let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let temp = tempfile::tempdir().expect("temp home");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
@@ -126,13 +159,13 @@ mod tests {
         let bob_server = super::super::new_ao_mcp_server_with_options(root.as_ref(), false, None, None, Some(bob));
         let input = || super::super::RunIdInput { run_id: workflow_id.to_string(), project_root: None };
 
-        let allowed = alice_server.output_run_inproc(input());
+        let allowed = alice_server.output_run_inproc(input()).await;
         let allowed_is_error = allowed.is_error;
         let payload = allowed.structured_content.expect("owned output");
         assert_ne!(allowed_is_error, Some(true), "{payload}");
         assert_eq!(payload.pointer("/result/0/text").and_then(Value::as_str), Some("ready"), "{payload}");
 
-        let denied = bob_server.output_run_inproc(input());
+        let denied = bob_server.output_run_inproc(input()).await;
         assert_eq!(denied.is_error, Some(true));
         let payload = denied.structured_content.expect("concealed output");
         assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("not_found"), "{payload}");
@@ -154,8 +187,9 @@ mod tests {
         assert_eq!(payload.pointer("/error/code").and_then(Value::as_str), Some("not_found"), "{payload}");
     }
 
-    #[test]
-    fn jsonl_and_monitor_share_typed_run_entries_without_a_child_cli() {
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // intentional: guards process-global env mutation across the awaits
+    async fn jsonl_and_monitor_share_typed_run_entries_without_a_child_cli() {
         let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let temp = tempfile::tempdir().expect("temp home");
         let _home = EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
@@ -171,20 +205,24 @@ mod tests {
         .expect("stdout events");
         let server = super::super::new_ao_mcp_server(project_root.to_string_lossy().as_ref());
 
-        let jsonl = server.output_jsonl_inproc(super::super::OutputJsonlInput {
-            run_id: run_id.to_string(),
-            entries: true,
-            project_root: None,
-        });
+        let jsonl = server
+            .output_jsonl_inproc(super::super::OutputJsonlInput {
+                run_id: run_id.to_string(),
+                entries: true,
+                project_root: None,
+            })
+            .await;
         let payload = jsonl.structured_content.expect("jsonl output");
         assert_eq!(payload.pointer("/result/0/source_file").and_then(Value::as_str), Some("stdout.jsonl"));
 
-        let monitor = server.output_monitor_inproc(super::super::OutputMonitorInput {
-            run_id: run_id.to_string(),
-            task_id: Some("TASK-971".to_string()),
-            phase_id: Some("build".to_string()),
-            project_root: None,
-        });
+        let monitor = server
+            .output_monitor_inproc(super::super::OutputMonitorInput {
+                run_id: run_id.to_string(),
+                task_id: Some("TASK-971".to_string()),
+                phase_id: Some("build".to_string()),
+                project_root: None,
+            })
+            .await;
         let payload = monitor.structured_content.expect("monitor output");
         assert_eq!(payload.pointer("/result/0/text").and_then(Value::as_str), Some("keep"));
         assert_eq!(payload.pointer("/result").and_then(Value::as_array).map(Vec::len), Some(1));

--- a/crates/orchestrator-cli/src/services/operations/ops_mcp/output_tools.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_mcp/output_tools.rs
@@ -8,7 +8,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<RunIdInput>()
     )]
     async fn ao_output_run(&self, params: Parameters<RunIdInput>) -> Result<CallToolResult, McpError> {
-        Ok(self.output_run_inproc(params.0))
+        Ok(self.output_run_inproc(params.0).await)
     }
 
     #[tool(
@@ -29,7 +29,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<OutputMonitorInput>()
     )]
     async fn ao_output_monitor(&self, params: Parameters<OutputMonitorInput>) -> Result<CallToolResult, McpError> {
-        Ok(self.output_monitor_inproc(params.0))
+        Ok(self.output_monitor_inproc(params.0).await)
     }
 
     #[tool(
@@ -56,7 +56,7 @@ impl AoMcpServer {
         input_schema = ao_schema_for_type::<OutputJsonlInput>()
     )]
     async fn ao_output_jsonl(&self, params: Parameters<OutputJsonlInput>) -> Result<CallToolResult, McpError> {
-        Ok(self.output_jsonl_inproc(params.0))
+        Ok(self.output_jsonl_inproc(params.0).await)
     }
 
     #[tool(

--- a/crates/orchestrator-cli/src/services/operations/ops_output.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_output.rs
@@ -169,6 +169,13 @@ fn resolve_workflow_id_for_run(project_root: &str, run_id: &str) -> Result<Optio
     if orchestrator_core::WorkflowStateManager::new(project_root).load_workflow_actor(run_id).is_some() {
         return Ok(Some(run_id.to_string()));
     }
+    // Node-executed runs may have no local runs/ state at all; the runner's
+    // `wf-<workflow_uuid>-<phase>-...` run ids still embed the workflow id.
+    if let Some(workflow_id) = super::ops_output_remote::workflow_id_from_run_id(run_id) {
+        if orchestrator_core::WorkflowStateManager::new(project_root).load_workflow_actor(&workflow_id).is_some() {
+            return Ok(Some(workflow_id));
+        }
+    }
     Ok(None)
 }
 
@@ -216,7 +223,7 @@ fn resolve_run_id_for_workflow_phase(project_root: &str, workflow_id: &str, phas
     Err(not_found_error(format!("no run recorded for phase '{phase_id}' of workflow {workflow_id}")))
 }
 
-fn extract_timestamp_hint(line: &str) -> Option<String> {
+pub(crate) fn extract_timestamp_hint(line: &str) -> Option<String> {
     let parsed = serde_json::from_str::<Value>(line).ok()?;
     parsed
         .get("timestamp")
@@ -254,6 +261,20 @@ pub(crate) fn get_run_jsonl_entries(project_root: &str, run_id: &str) -> Result<
 
     rows.sort_by(|a, b| a.timestamp_hint.cmp(&b.timestamp_hint));
     Ok(rows)
+}
+
+/// Local-first read of a run's jsonl rows, falling back to the project's
+/// `log_storage_backend` plugin when no local `runs/<run_id>/` directory
+/// exists (node-executed runs — see `ops_output_remote`). A local run dir
+/// that exists but is empty does NOT trigger the remote read.
+pub(crate) async fn get_run_jsonl_entries_with_remote(
+    project_root: &str,
+    run_id: &str,
+) -> Result<Vec<RunJsonlEntryCli>> {
+    if resolve_run_dir_for_lookup(project_root, run_id)?.is_some() {
+        return get_run_jsonl_entries(project_root, run_id);
+    }
+    super::ops_output_remote::remote_run_jsonl_entries(project_root, run_id).await
 }
 
 fn infer_cli_from_jsonl(entries: &[RunJsonlEntryCli]) -> Option<String> {
@@ -324,7 +345,7 @@ fn ensure_safe_workflow_id(workflow_id: &str) -> Result<()> {
     ensure_safe_id_segment("workflow id", workflow_id)
 }
 
-pub(crate) fn output_read_application(
+pub(crate) async fn output_read_application(
     project_root: &str,
     run_id: Option<&str>,
     workflow_id: Option<&str>,
@@ -334,10 +355,34 @@ pub(crate) fn output_read_application(
     ensure_output_actor_access(project_root, workflow_id, run_id, actor)?;
     let resolved_run_id = match (phase, workflow_id) {
         (Some(phase), Some(workflow_id)) => resolve_run_id_for_workflow_phase(project_root, workflow_id, phase)?,
-        _ => resolve_run_id_arg(project_root, run_id.map(str::to_string), workflow_id.map(str::to_string))?,
+        _ => match resolve_run_id_arg(project_root, run_id.map(str::to_string), workflow_id.map(str::to_string)) {
+            Ok(run_id) => run_id,
+            Err(err) => {
+                // No local run was ever recorded for this workflow — try the
+                // log_storage backend before giving up (node-executed runs).
+                if let Some(workflow_id) = workflow_id {
+                    let events = super::ops_output_remote::remote_workflow_events(project_root, workflow_id).await?;
+                    if !events.is_empty() {
+                        return Ok(events);
+                    }
+                }
+                return Err(err);
+            }
+        },
     };
-    let run_dir = resolve_run_dir_for_lookup(project_root, &resolved_run_id)?
-        .ok_or_else(|| not_found_error(format!("run directory not found for {resolved_run_id}")))?;
+    let run_dir = match resolve_run_dir_for_lookup(project_root, &resolved_run_id)? {
+        Some(run_dir) => run_dir,
+        None => {
+            // The run resolved (e.g. via session checkpoints) but its run dir
+            // is gone, or it executed on a node — read the transcript back
+            // from the log_storage backend when one is configured.
+            let events = super::ops_output_remote::remote_run_events(project_root, &resolved_run_id).await?;
+            if !events.is_empty() {
+                return Ok(events);
+            }
+            return Err(not_found_error(format!("run directory not found for {resolved_run_id}")));
+        }
+    };
     let events_path = run_dir.join("events.jsonl");
     if !events_path.exists() {
         return Ok(Vec::new());
@@ -364,8 +409,8 @@ pub(crate) fn output_artifacts_application(project_root: &str, execution_id: &st
     list_artifact_infos(project_root, execution_id)
 }
 
-pub(crate) fn output_jsonl_application(project_root: &str, run_id: &str, include_entries: bool) -> Result<Value> {
-    let entries = get_run_jsonl_entries(project_root, run_id)?;
+pub(crate) async fn output_jsonl_application(project_root: &str, run_id: &str, include_entries: bool) -> Result<Value> {
+    let entries = get_run_jsonl_entries_with_remote(project_root, run_id).await?;
     if include_entries {
         Ok(serde_json::to_value(entries)?)
     } else {
@@ -373,13 +418,13 @@ pub(crate) fn output_jsonl_application(project_root: &str, run_id: &str, include
     }
 }
 
-pub(crate) fn output_monitor_application(
+pub(crate) async fn output_monitor_application(
     project_root: &str,
     run_id: &str,
     task_id: Option<&str>,
     phase_id: Option<&str>,
 ) -> Result<Vec<Value>> {
-    let entries = get_run_jsonl_entries(project_root, run_id)?;
+    let entries = get_run_jsonl_entries_with_remote(project_root, run_id).await?;
     let mut events = Vec::new();
     for entry in entries {
         let Ok(payload) = serde_json::from_str::<Value>(&entry.line) else {
@@ -452,7 +497,8 @@ pub(crate) async fn handle_output(command: OutputCommand, project_root: &str, js
                     args.workflow_id.as_deref(),
                     args.phase.as_deref(),
                     actor.as_ref(),
-                )?,
+                )
+                .await?,
                 json,
             )
         }
@@ -498,14 +544,15 @@ pub(crate) async fn handle_output(command: OutputCommand, project_root: &str, js
             )
         }
         OutputCommand::Jsonl(args) => {
-            print_value(output_jsonl_application(project_root, &args.run_id, args.entries)?, json)
+            print_value(output_jsonl_application(project_root, &args.run_id, args.entries).await?, json)
         }
         OutputCommand::Monitor(args) => print_value(
-            output_monitor_application(project_root, &args.run_id, args.task_id.as_deref(), args.phase_id.as_deref())?,
+            output_monitor_application(project_root, &args.run_id, args.task_id.as_deref(), args.phase_id.as_deref())
+                .await?,
             json,
         ),
         OutputCommand::Cli(args) => {
-            let entries = get_run_jsonl_entries(project_root, &args.run_id)?;
+            let entries = get_run_jsonl_entries_with_remote(project_root, &args.run_id).await?;
             print_value(
                 serde_json::json!({
                     "run_id": args.run_id,

--- a/crates/orchestrator-cli/src/services/operations/ops_output_remote.rs
+++ b/crates/orchestrator-cli/src/services/operations/ops_output_remote.rs
@@ -1,0 +1,417 @@
+//! log_storage-backed read fallback for `animus output` when the local
+//! `runs/<run_id>/` directory is absent — the node-executed run case, where
+//! the transcript only exists in the configured `log_storage_backend`
+//! plugin (e.g. `animus-log-storage-s3`).
+//!
+//! ## Storage contract (writer side)
+//!
+//! Writers (the workflow runner / daemon offload path) store one
+//! [`LogEntry`] per run-dir JSONL row with:
+//!
+//! - `source` = `workflow`, `source_name` = the workflow id (the protocol's
+//!   own convention for [`LogSource::Workflow`]; also prefix-narrows the
+//!   backend scan);
+//! - `target` = `workflow.run.<event-kind>`;
+//! - `fields.run_id` / `fields.workflow_id` — the owning run / workflow;
+//! - `fields.source_file` — the run-dir file the row came from
+//!   (`events.jsonl`, `json-output.jsonl`, ...);
+//! - `fields.run_event` — the original JSONL row object, verbatim.
+//!
+//! Readers below query by `source_name`, filter on `fields.run_id`
+//! in-process, and rebuild rows from `fields.run_event`. Entries that do
+//! not carry `fields.run_event` are not transcript rows and are skipped.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use animus_log_storage_protocol::{LogEntry, LogQueryResult, LogSource};
+use anyhow::Result;
+use orchestrator_daemon_runtime::{spawn_log_storage_supervisor, LogStorageHandle};
+use serde_json::Value;
+
+use super::ops_output::{extract_timestamp_hint, RunJsonlEntryCli};
+
+/// Upper bound on entries pulled in one remote transcript read. `query`
+/// keeps the NEWEST `limit` entries, so a transcript larger than this loses
+/// its oldest events first — sized far above a normal run so that only
+/// pathological transcripts truncate.
+const REMOTE_RUN_QUERY_LIMIT: usize = 10_000;
+
+/// One remote read fans out into per-object fetches in the backend; allow
+/// for a cold plugin spawn + a large transcript without hanging the CLI.
+const REMOTE_RUN_QUERY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Derive the workflow id from a `wf-<workflow_uuid>[-<phase>-...]` run id
+/// (the runner's per-phase run-dir naming). Returns `None` for run ids that
+/// do not follow that scheme.
+pub(crate) fn workflow_id_from_run_id(run_id: &str) -> Option<String> {
+    let rest = run_id.strip_prefix("wf-")?;
+    let candidate = rest.get(..36)?;
+    if !rest[36..].is_empty() && !rest[36..].starts_with('-') {
+        return None;
+    }
+    uuid::Uuid::parse_str(candidate).ok()?;
+    Some(candidate.to_string())
+}
+
+/// Rebuild one jsonl row from a stored [`LogEntry`] per the contract above.
+/// Returns `None` for entries that are not transcript rows.
+fn log_entry_to_jsonl_row(entry: &LogEntry) -> Option<RunJsonlEntryCli> {
+    let run_event = entry.fields.get("run_event")?;
+    let source_file = entry.fields.get("source_file").and_then(Value::as_str).unwrap_or("events.jsonl").to_string();
+    let line = serde_json::to_string(run_event).ok()?;
+    let timestamp_hint = extract_timestamp_hint(&line).or_else(|| Some(entry.ts.to_rfc3339()));
+    Some(RunJsonlEntryCli { source_file, line, timestamp_hint })
+}
+
+/// Whether `entry` belongs to `run_id` per the contract. Entries stored
+/// under a run-id `source_name` without a `fields.run_id` (older writers)
+/// are kept; a mismatched `fields.run_id` always drops.
+fn entry_belongs_to_run(entry: &LogEntry, run_id: &str) -> bool {
+    match entry.fields.get("run_id").and_then(Value::as_str) {
+        Some(value) => value == run_id,
+        None => entry.source_name.as_deref() == Some(run_id),
+    }
+}
+
+/// Spawn the project's `log_storage_backend` plugin, if one is installed.
+/// Returns `None` when the project has no plugin-routed backend (the
+/// in-tree fallback holds no remote run data).
+async fn spawn_plugin_handle(project_root: &str) -> Option<Arc<LogStorageHandle>> {
+    let outcome = spawn_log_storage_supervisor(Path::new(project_root)).await;
+    let handle = outcome.handle;
+    if handle.is_plugin() {
+        Some(handle)
+    } else {
+        handle.shutdown().await;
+        None
+    }
+}
+
+/// Query a plugin `handle` for transcript rows stored under `source_name`,
+/// optionally restricted to one run.
+async fn query_remote_rows(
+    handle: &LogStorageHandle,
+    source_name: &str,
+    run_id_filter: Option<&str>,
+) -> Result<Vec<RunJsonlEntryCli>> {
+    let params = serde_json::json!({
+        "source": LogSource::Workflow,
+        "source_name": source_name,
+        "limit": REMOTE_RUN_QUERY_LIMIT,
+    });
+    let value = handle.tail(Some(params), REMOTE_RUN_QUERY_TIMEOUT).await?.unwrap_or(Value::Null);
+    let result: LogQueryResult = serde_json::from_value(value)?;
+    let mut rows: Vec<RunJsonlEntryCli> = result
+        .entries
+        .iter()
+        .filter(|entry| match run_id_filter {
+            Some(run_id) => entry_belongs_to_run(entry, run_id),
+            None => true,
+        })
+        .filter_map(log_entry_to_jsonl_row)
+        .collect();
+    rows.sort_by(|a, b| a.timestamp_hint.cmp(&b.timestamp_hint));
+    Ok(rows)
+}
+
+/// Read a run's transcript rows from the log_storage backend. Tries the
+/// workflow-id `source_name` first (derived from `wf-<uuid>-...` run ids,
+/// filtered to the run), then a run-id `source_name` for writers that key
+/// by run id directly. Empty when no plugin backend is installed or the
+/// backend holds nothing for the run.
+pub(crate) async fn remote_run_jsonl_entries(project_root: &str, run_id: &str) -> Result<Vec<RunJsonlEntryCli>> {
+    let Some(handle) = spawn_plugin_handle(project_root).await else {
+        return Ok(Vec::new());
+    };
+    let mut source_names: Vec<String> = Vec::new();
+    if let Some(workflow_id) = workflow_id_from_run_id(run_id) {
+        source_names.push(workflow_id);
+    }
+    if !source_names.iter().any(|name| name == run_id) {
+        source_names.push(run_id.to_string());
+    }
+    let mut rows = Vec::new();
+    for source_name in &source_names {
+        match query_remote_rows(&handle, source_name, Some(run_id)).await {
+            Ok(found) if !found.is_empty() => {
+                rows = found;
+                break;
+            }
+            Ok(_) => {}
+            Err(err) => {
+                handle.shutdown().await;
+                return Err(err);
+            }
+        }
+    }
+    handle.shutdown().await;
+    Ok(rows)
+}
+
+/// Read every transcript event payload stored for a workflow (all runs,
+/// chronological) from the log_storage backend — the `output read
+/// --workflow-id` fallback when no local run was ever recorded.
+pub(crate) async fn remote_workflow_events(project_root: &str, workflow_id: &str) -> Result<Vec<Value>> {
+    let Some(handle) = spawn_plugin_handle(project_root).await else {
+        return Ok(Vec::new());
+    };
+    let result = query_remote_rows(&handle, workflow_id, None).await;
+    handle.shutdown().await;
+    Ok(result?
+        .into_iter()
+        .filter(|row| row.source_file == "events.jsonl")
+        .filter_map(|row| serde_json::from_str::<Value>(&row.line).ok())
+        .collect())
+}
+
+/// Read one run's `events.jsonl` payloads from the log_storage backend.
+pub(crate) async fn remote_run_events(project_root: &str, run_id: &str) -> Result<Vec<Value>> {
+    Ok(remote_run_jsonl_entries(project_root, run_id)
+        .await?
+        .into_iter()
+        .filter(|row| row.source_file == "events.jsonl")
+        .filter_map(|row| serde_json::from_str::<Value>(&row.line).ok())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use animus_log_storage_protocol::LogLevel;
+    use chrono::{DateTime, Utc};
+    use orchestrator_plugin_host::PluginHost;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    fn ts(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    fn transcript_entry(
+        id: &str,
+        source_name: &str,
+        run_id: &str,
+        source_file: &str,
+        ts: DateTime<Utc>,
+        kind: &str,
+    ) -> LogEntry {
+        LogEntry {
+            id: id.into(),
+            ts,
+            level: LogLevel::Info,
+            source: LogSource::Workflow,
+            source_name: Some(source_name.into()),
+            target: format!("workflow.run.{kind}"),
+            message: kind.into(),
+            fields: serde_json::json!({
+                "run_id": run_id,
+                "workflow_id": "wf-owner",
+                "source_file": source_file,
+                "run_event": {
+                    "kind": kind,
+                    "run_id": run_id,
+                    "timestamp": ts.to_rfc3339(),
+                    "text": format!("payload-{id}"),
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn workflow_id_derivation_from_wf_run_ids() {
+        assert_eq!(
+            workflow_id_from_run_id("wf-31184ea3-55fd-4ea3-ae65-284a1fda3042-pr-rework-0-c0-a1-5dc8555b"),
+            Some("31184ea3-55fd-4ea3-ae65-284a1fda3042".to_string())
+        );
+        // Legacy bare `wf-<uuid>` run dir name.
+        assert_eq!(
+            workflow_id_from_run_id("wf-31184ea3-55fd-4ea3-ae65-284a1fda3042"),
+            Some("31184ea3-55fd-4ea3-ae65-284a1fda3042".to_string())
+        );
+        assert_eq!(workflow_id_from_run_id("run-output"), None);
+        assert_eq!(workflow_id_from_run_id("wf-not-a-uuid"), None);
+        assert_eq!(workflow_id_from_run_id("wf-31184ea3-55fd-4ea3-ae65-284a1fda304"), None);
+        // Trailing segment must be `-`-separated, not a UUID continuation.
+        assert_eq!(workflow_id_from_run_id("wf-31184ea3-55fd-4ea3-ae65-284a1fda3042extra"), None);
+    }
+
+    #[test]
+    fn maps_contract_entries_to_jsonl_rows_and_skips_others() {
+        let entry = transcript_entry(
+            "e1",
+            "wf-owner",
+            "wf-owner-build-0",
+            "stdout.jsonl",
+            ts("2026-09-01T10:00:00Z"),
+            "output_chunk",
+        );
+        let row = log_entry_to_jsonl_row(&entry).expect("transcript row");
+        assert_eq!(row.source_file, "stdout.jsonl");
+        let payload: Value = serde_json::from_str(&row.line).unwrap();
+        assert_eq!(payload.pointer("/text").and_then(Value::as_str), Some("payload-e1"));
+        assert_eq!(row.timestamp_hint.as_deref(), Some("2026-09-01T10:00:00+00:00"));
+
+        // A daemon-style entry without `fields.run_event` is not a transcript row.
+        let mut other = entry.clone();
+        other.fields = serde_json::json!({ "seq": 1 });
+        assert!(log_entry_to_jsonl_row(&other).is_none());
+    }
+
+    #[test]
+    fn run_membership_filter_rules() {
+        let entry = transcript_entry("e1", "wf-owner", "run-a", "events.jsonl", ts("2026-09-01T10:00:00Z"), "started");
+        assert!(entry_belongs_to_run(&entry, "run-a"));
+        assert!(!entry_belongs_to_run(&entry, "run-b"));
+        // Legacy entries keyed by run-id source_name without fields.run_id.
+        let mut legacy = entry.clone();
+        legacy.source_name = Some("run-a".into());
+        legacy.fields = serde_json::json!({ "run_event": { "kind": "started" } });
+        assert!(entry_belongs_to_run(&legacy, "run-a"));
+        assert!(!entry_belongs_to_run(&legacy, "run-b"));
+    }
+
+    // -----------------------------------------------------------------
+    // In-process fake `log_storage_backend` over duplex streams, mirroring
+    // the daemon-runtime `fake_log_storage_host` test pattern.
+    // -----------------------------------------------------------------
+
+    type RecordedCall = (String, Option<Value>);
+
+    async fn fake_log_storage_host(query_response: Value, recorded_calls: Arc<Mutex<Vec<RecordedCall>>>) -> PluginHost {
+        use animus_plugin_protocol::{InitializeResult, PluginCapabilities, PluginInfo, RpcRequest, RpcResponse};
+        use tokio::io::{duplex, AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+        let (host_reader, mut plugin_writer) = duplex(8192);
+        let (plugin_reader, host_writer) = duplex(8192);
+        let recorded = recorded_calls.clone();
+
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(plugin_reader);
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).await.expect("read line") == 0 {
+                    break;
+                }
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let value: Value = match serde_json::from_str(trimmed) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                if value.get("id").is_none() || value.get("id") == Some(&Value::Null) {
+                    continue; // notifications
+                }
+                let request: RpcRequest = match serde_json::from_value(value) {
+                    Ok(r) => r,
+                    Err(_) => continue,
+                };
+                let response = match request.method.as_str() {
+                    "initialize" => RpcResponse::ok(
+                        request.id,
+                        serde_json::json!(InitializeResult {
+                            protocol_version: "1.0.0".to_string(),
+                            plugin_info: PluginInfo {
+                                name: "fake-log-storage".to_string(),
+                                version: "0.1.0".to_string(),
+                                plugin_kind: "log_storage_backend".to_string(),
+                                plugin_kinds: vec![],
+                                description: None,
+                            },
+                            capabilities: PluginCapabilities::default(),
+                            kind_capabilities: std::collections::HashMap::new(),
+                        }),
+                    ),
+                    method => {
+                        recorded.lock().await.push((method.to_string(), request.params.clone()));
+                        if method == "log_storage/query" {
+                            RpcResponse::ok(request.id, query_response.clone())
+                        } else {
+                            RpcResponse::ok(request.id, serde_json::json!({}))
+                        }
+                    }
+                };
+                let mut encoded = serde_json::to_string(&response).expect("encode response");
+                encoded.push('\n');
+                if plugin_writer.write_all(encoded.as_bytes()).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        PluginHost::from_streams("fake-log-storage", host_reader, host_writer)
+    }
+
+    async fn plugin_handle(query_response: Value) -> (LogStorageHandle, Arc<Mutex<Vec<RecordedCall>>>) {
+        let recorded: Arc<Mutex<Vec<RecordedCall>>> = Arc::new(Mutex::new(Vec::new()));
+        let host = fake_log_storage_host(query_response, recorded.clone()).await;
+        host.handshake().await.expect("handshake");
+        (
+            LogStorageHandle::from_handshaked_host("fake-log-storage", host, std::path::PathBuf::from("/tmp/project")),
+            recorded,
+        )
+    }
+
+    #[tokio::test]
+    async fn query_remote_rows_filters_to_run_and_sorts_chronologically() {
+        let wf_id = "31184ea3-55fd-4ea3-ae65-284a1fda3042";
+        let run_a = format!("wf-{wf_id}-build-0-c0-a1-aaaa");
+        let run_b = format!("wf-{wf_id}-verify-1-c0-a1-bbbb");
+        let entries = vec![
+            // Deliberately unordered on the wire: query contract is oldest-first
+            // but the row-level sort must hold regardless.
+            transcript_entry("e2", wf_id, &run_a, "events.jsonl", ts("2026-09-01T10:00:05Z"), "finished"),
+            transcript_entry("e1", wf_id, &run_a, "events.jsonl", ts("2026-09-01T10:00:00Z"), "started"),
+            transcript_entry("e9", wf_id, &run_b, "events.jsonl", ts("2026-09-01T10:00:02Z"), "started"),
+        ];
+        let response = serde_json::to_value(LogQueryResult { entries, next_cursor: None }).unwrap();
+        let (handle, recorded) = plugin_handle(response).await;
+
+        let rows = query_remote_rows(&handle, wf_id, Some(&run_a)).await.expect("query");
+        assert_eq!(rows.len(), 2, "run_b entries must be filtered out");
+        let kinds: Vec<String> = rows
+            .iter()
+            .map(|row| {
+                let payload: Value = serde_json::from_str(&row.line).unwrap();
+                payload.pointer("/kind").and_then(Value::as_str).unwrap().to_string()
+            })
+            .collect();
+        assert_eq!(kinds, ["started", "finished"]);
+
+        // The wire request narrows by source + source_name with a high limit.
+        let calls = recorded.lock().await;
+        let (method, params) = calls.iter().find(|(m, _)| m == "log_storage/query").expect("query call");
+        assert_eq!(method, "log_storage/query");
+        let params = params.clone().expect("query params");
+        assert_eq!(params.pointer("/source").and_then(Value::as_str), Some("workflow"));
+        assert_eq!(params.pointer("/source_name").and_then(Value::as_str), Some(wf_id));
+        assert!(params.pointer("/limit").and_then(Value::as_u64).unwrap() >= 10_000);
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // intentional: guards process-global env mutation across the await
+    async fn remote_run_jsonl_entries_without_plugin_returns_empty() {
+        let _lock = crate::shared::test_env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().expect("temp home");
+        let _home = protocol::test_utils::EnvVarGuard::set("HOME", Some(temp.path().to_string_lossy().as_ref()));
+        let _config = protocol::test_utils::EnvVarGuard::set(
+            "ANIMUS_CONFIG_DIR",
+            Some(temp.path().join("config").to_string_lossy().as_ref()),
+        );
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root).expect("project root");
+
+        let rows = remote_run_jsonl_entries(
+            project_root.to_string_lossy().as_ref(),
+            "wf-31184ea3-55fd-4ea3-ae65-284a1fda3042-build-0",
+        )
+        .await
+        .expect("no-plugin fallback must not error");
+        assert!(rows.is_empty());
+    }
+}

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ if you are upgrading from an earlier v0.4.x.
 
 Use the installer published from `launchapp-dev/animus-cli`:
 
-Current workspace CLI version: **v0.7.0-rc.40**.
+Current workspace CLI version: **v0.7.0-rc.42**.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
@@ -28,7 +28,7 @@ Options:
 
 ```bash
 # Install a specific release
-ANIMUS_VERSION=v0.7.0-rc.40 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
+ANIMUS_VERSION=v0.7.0-rc.42 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
 
 # Install into a custom directory
 ANIMUS_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -15,7 +15,7 @@ time so the container boots without network access.
 ```dockerfile
 # ---- stage 1: fetch the prebuilt animus binary ----
 FROM debian:bookworm-slim AS animus-fetch
-ARG ANIMUS_VERSION=v0.7.0-rc.40
+ARG ANIMUS_VERSION=v0.7.0-rc.42
 ARG ANIMUS_TARGET=x86_64-unknown-linux-gnu
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -82,7 +82,7 @@ CMD ["/app/deploy/start.sh"]
 
 | ARG | Default | Description |
 |---|---|---|
-| `ANIMUS_VERSION` | `v0.7.0-rc.40` | Release tag to download from `launchapp-dev/animus-cli` |
+| `ANIMUS_VERSION` | `v0.7.0-rc.42` | Release tag to download from `launchapp-dev/animus-cli` |
 | `ANIMUS_TARGET` | `x86_64-unknown-linux-gnu` | Target triple; must match the container's glibc |
 | `SIG` | `--signature-policy=disabled` | Signature policy flag passed to every `plugin install` |
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -306,13 +306,13 @@ animus
 │   └── revoke-trust         Revoke trust for a GitHub org (tombstones `revoked_at` so re-installs re-prompt); the built-in `launchapp-dev` org cannot be revoked
 │
 ├── status                   Show a unified project status dashboard. `--failures N` sets how many recent workflow failures to list (default 3; applies to both human and JSON output). Human view includes three additional sections: **Task Summary** (live from SubjectRouter; renders "unavailable" with an error when the router is unreachable), **Blocked / Paused** (id + reason + blocked_by + age), and **Needs You** (pending agent interactions with answer-command hints). The Daemon section reports `provider_plugins_healthy` (the replacement for the removed `runner_connected`/`runner_pid` fields, which were dropped from both the human view and the `--json` envelope)
-├── output                   Inspect run output and artifacts
-│   ├── read                 Read run event payloads (`--run-id`, or `--workflow-id` to resolve the latest run recorded for that workflow; clear error when none or ambiguous)
+├── output                   Inspect run output and artifacts. When the local `runs/<run_id>/` directory is absent (node-executed runs), `read`/`jsonl`/`monitor`/`cli` fall back to the project's `log_storage_backend` plugin (`log_storage/query` with `source: "workflow"`, `source_name: <workflow-id>`, filtered to `fields.run_id`); entries must carry `fields.run_event` + `fields.source_file` per the writer contract in `crates/orchestrator-cli/src/services/operations/ops_output_remote.rs`
+│   ├── read                 Read run event payloads (`--run-id`, or `--workflow-id` to resolve the latest run recorded for that workflow; clear error when none or ambiguous). When no local run is recorded for `--workflow-id` at all, reads the workflow's events back from the log_storage backend
 │   ├── phase-outputs        Read persisted workflow phase outputs. Human view renders one block per phase (verdict, reason, commit) plus a Skills section — requested vs applied (with source scope and contribution kinds) vs missing — so an attached skill is verifiably applied, never a silent no-op; `--json` carries the raw outputs incl. the persisted skill records
 │   ├── artifacts            List artifacts for an execution id
 │   ├── download             Download an artifact payload
-│   ├── jsonl                Read aggregated JSONL output streams for a run
-│   ├── monitor              Inspect run output with optional task/phase filtering
+│   ├── jsonl                Read aggregated JSONL output streams for a run (log_storage fallback when the local run dir is absent)
+│   ├── monitor              Inspect run output with optional task/phase filtering (log_storage fallback when the local run dir is absent)
 │   ├── cli                  Infer CLI provider details from run output
 │   └── decisions            Read the per-run LLM decision log (`runs/<run_id>/decisions.jsonl`: session header, prompts, tool calls/results, errors) by `--run-id` or `--workflow-id`. Distinct from `workflow decisions`, which shows phase-advance decision history stored on workflow state
 │


### PR DESCRIPTION
## TASK-1462 (REQUIREMENT-082 slice 1) — `animus output` reads node-run transcripts back from log_storage

**Problem.** `animus output read|jsonl|monitor|cli` read only local `runs/<run_id>/` dirs. For runs executed on ephemeral Railway nodes, when the transcript is absent locally (pruned / never mirrored), these commands return empty or not-found and operators cannot see what the agent did. The Portal transcript view (`GET /api/workflows/:id/logs`) already falls back to `animus output read --workflow-id`, so it inherits this fix with no Portal change.

**Change.** When the local run dir is absent, the output commands fall back to the project's installed `log_storage_backend` plugin via `log_storage/query`, reusing the daemon's `spawn_log_storage_supervisor` / `LogStorageHandle` (spawn → bounded query → shutdown per invocation; no plugin installed ⇒ same empty/not-found behavior as before).

- `ops_output_remote.rs` (new): documents the writer contract (`source: "workflow"`, `source_name` = workflow id per the protocol convention, `fields.run_id` / `fields.source_file` / `fields.run_event`), derives the workflow id from `wf-<uuid>-<phase>-...` run ids, maps stored `LogEntry`s back to jsonl rows, filters per-run, sorts chronologically.
- `ops_output.rs`: `get_run_jsonl_entries_with_remote` (local-first; a present-but-empty local dir does not trigger a remote read); `output_read_application` / `output_jsonl_application` / `output_monitor_application` are now async; `--workflow-id` with **no** local runs recorded reads workflow-scoped events from the backend before erroring; `resolve_workflow_id_for_run` derives the workflow id from `wf-`-prefixed run ids so MCP actor gating still works for remote runs.
- MCP `animus.output.run` / `.monitor` / `.jsonl` share the same fallback via a new async `run_output_application_async`.
- `docs/reference/cli/index.md` updated per repo policy.

**Scope note (important).** Today only **daemon lifecycle events** are teed into log_storage; no component ships run transcripts as `source: "workflow"` entries yet (the runner's `phase_executor.rs:2809` / `workflow_session.rs:745` comments assume a daemon offload that does not exist). The transcript **writer** is the required follow-up slice — this PR defines and tests the read contract it must write, against a fake in-process plugin. Companion PR: launchapp-dev/animus-log-storage-s3#2 (read-path tests + documented contract; no protocol change needed — `query`/`tail` already cover it).

## Tests

- New: `ops_output_remote` unit tests (run-id→workflow-id derivation, entry→row mapping, membership filter) + integration tests over a fake `log_storage_backend` on duplex streams (asserts the `log_storage/query` wire params, per-run filtering, chronological sort) + a no-plugin-installed regression (empty, no error). Existing ops_output/output_inproc tests updated to async.
- `cargo test -p orchestrator-cli`: **1540 passed, 0 failed**
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `scripts/check-doc-sync.sh`: exit 0 (pre-existing README `rc.40` vs `rc.42` version drift warning unchanged — not from this PR)

## Release implications

No new dependencies (uses the already-pinned `animus-log-storage-protocol` and `orchestrator-daemon-runtime` re-exports). Requires the normal runtime release flow (merge → tag → Portal pin update) before the Portal benefits; production proof additionally requires the transcript writer slice.