### PR TITLE
fix(daemon): cap phase-skills spawn payload below Linux MAX_ARG_STRLEN (TASK-001)

### DIFF
--- a/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_task_dispatch.rs
+++ b/crates/orchestrator-cli/src/services/runtime/runtime_daemon/daemon_task_dispatch.rs
@@ -11,6 +11,14 @@ use tracing::warn;
 
 use crate::services::plugin_clients;
 
+/// `tracing::warn!` output never reaches Railway-hosted logs (no subscriber is
+/// installed on the daemon's stderr), which left every dispatch-leg failure
+/// invisible in production (TASK-001). Surface each failure on STDOUT too —
+/// same pattern as `emit_reconcile_suppressed` in daemon_reconciliation.rs.
+fn dispatch_warn_stdout(msg: &str) {
+    println!("dispatch-warn ts={} {msg}", chrono::Utc::now().to_rfc3339());
+}
+
 pub async fn dispatch_queued_entries_via_runner(
     root: &str,
     process_manager: &mut ProcessManager,
@@ -46,6 +54,12 @@ pub async fn dispatch_queued_entries_via_runner(
             conflict_workflow_id = block.conflicts_with.as_ref().map(|fence| fence.workflow_id.as_str()),
             "queue/v2/lease left a candidate blocked without consuming a coding slot"
         );
+        dispatch_warn_stdout(&format!(
+            "entry_id={} reason={:?} conflict_workflow_id={} queue/v2/lease left a candidate blocked without consuming a coding slot",
+            block.entry_id,
+            block.reason,
+            block.conflicts_with.as_ref().map(|fence| fence.workflow_id.as_str()).unwrap_or("none"),
+        ));
     }
 
     let mut planned_starts = Vec::new();
@@ -58,6 +72,10 @@ pub async fn dispatch_queued_entries_via_runner(
                 error = %error,
                 "queue/v2/lease returned an invalid fleet fence; leaving it assigned for explicit recovery"
             );
+            dispatch_warn_stdout(&format!(
+                "entry_id={} error={} queue/v2/lease returned an invalid fleet fence; leaving it assigned for explicit recovery",
+                fenced.entry.entry_id, error,
+            ));
             continue;
         }
         let queue = fenced.execution.queue_lease.as_ref().expect("validated queue-backed lease");
@@ -69,6 +87,10 @@ pub async fn dispatch_queued_entries_via_runner(
                 actual_owner = %queue.owner_id,
                 "queue/v2/lease returned a different owner; leaving entry assigned and refusing spawn"
             );
+            dispatch_warn_stdout(&format!(
+                "entry_id={} expected_owner={} actual_owner={} queue/v2/lease returned a different owner; leaving entry assigned and refusing spawn",
+                fenced.entry.entry_id, owner_id, queue.owner_id,
+            ));
             continue;
         }
 
@@ -81,6 +103,10 @@ pub async fn dispatch_queued_entries_via_runner(
                     error = %error,
                     "queue/v2/lease returned an undecodable dispatch"
                 );
+                dispatch_warn_stdout(&format!(
+                    "entry_id={} error={} queue/v2/lease returned an undecodable dispatch; completing failed",
+                    fenced.entry.entry_id, error,
+                ));
                 complete_failed(project_root, coding_scheduler, &fenced.execution, None).await;
                 continue;
             }
@@ -94,6 +120,10 @@ pub async fn dispatch_queued_entries_via_runner(
                     error = %error,
                     "queue/v2/lease subject dispatch drifted from the kernel protocol"
                 );
+                dispatch_warn_stdout(&format!(
+                    "entry_id={} error={} queue/v2/lease subject dispatch drifted from the kernel protocol; completing failed",
+                    fenced.entry.entry_id, error,
+                ));
                 complete_failed(project_root, coding_scheduler, &fenced.execution, None).await;
                 continue;
             }
@@ -113,6 +143,10 @@ pub async fn dispatch_queued_entries_via_runner(
                     collision = ?reason,
                     "local fleet projection rejected queue-owned lease; returning exact lease to pending"
                 );
+                dispatch_warn_stdout(&format!(
+                    "entry_id={} collision={:?} local fleet projection rejected queue-owned lease; returning exact lease to pending",
+                    fenced.entry.entry_id, reason,
+                ));
                 release_to_pending(project_root, coding_scheduler, &fenced.execution, "local-fleet-collision").await;
                 continue;
             }
@@ -149,6 +183,18 @@ pub async fn dispatch_queued_entries_via_runner(
                 .await;
             }
         }
+    }
+    // TASK-001: a leased-but-never-started dispatch used to be indistinguishable
+    // from "the dispatch leg never ran" in hosted logs. Print one summary line
+    // whenever the queue lease returned work.
+    if !leased.is_empty() || !planned_starts.is_empty() {
+        println!(
+            "dispatch-tick ts={} leased={} planned={} started={}",
+            chrono::Utc::now().to_rfc3339(),
+            leased.len(),
+            planned_starts.len(),
+            summary.started,
+        );
     }
     Ok(summary)
 }
@@ -299,6 +345,10 @@ async fn complete_failed(
             error = %error,
             "queue/v2/completion failed; retaining local reservation for recovery"
         );
+        dispatch_warn_stdout(&format!(
+            "workflow_id={} error={} queue/v2/completion failed; retaining local reservation for recovery",
+            execution.workflow_id, error,
+        ));
     }
 }
 
@@ -323,6 +373,12 @@ impl DispatchNoticeSink for CliDispatchNoticeSink {
                     error = %error,
                     "failed to start workflow runner"
                 );
+                dispatch_warn_stdout(&format!(
+                    "subject_id={} workflow_ref={} error={} failed to start workflow runner",
+                    dispatch.subject_id().unwrap_or_default(),
+                    dispatch.workflow_ref,
+                    error,
+                ));
                 self.outcomes.push(DispatchEntryOutcome::Failed);
             }
             DispatchNotice::Deferred { dispatch, reason } => {
@@ -332,6 +388,12 @@ impl DispatchNoticeSink for CliDispatchNoticeSink {
                     reason = %reason,
                     "workflow runner spawn deferred; exact queue fence returns to pending"
                 );
+                dispatch_warn_stdout(&format!(
+                    "subject_id={} workflow_ref={} reason={} workflow runner spawn deferred; exact queue fence returns to pending",
+                    dispatch.subject_id().unwrap_or_default(),
+                    dispatch.workflow_ref,
+                    reason,
+                ));
                 self.outcomes.push(DispatchEntryOutcome::Deferred);
             }
             _ => {}

--- a/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_execution.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/dispatch_execution.rs
@@ -54,7 +54,10 @@ where
                 } else {
                     notice_sink.notice(DispatchNotice::Failed {
                         dispatch: planned_start.dispatch.clone(),
-                        error: error.to_string(),
+                        // TASK-001: keep the full cause chain — the OS-level
+                        // spawn error (ENOENT/E2BIG/...) lives one level below
+                        // anyhow's top context and is the only useful part.
+                        error: format!("{error:#}"),
                     });
                 }
             }

--- a/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
@@ -85,13 +85,19 @@ const DAEMON_MANAGED_RUNNER_ENV_KEYS: &[&str] = &[
 /// warning; the runner then resolves skills locally (its no-payload
 /// fallback), so nothing is lost beyond the daemon-side resolution log.
 /// Windows caps the entire process environment block at ~32 KiB, so the cap
-/// there must leave headroom for the inherited daemon environment; Unix
-/// limits (ARG_MAX-style, typically >= 1 MiB shared) allow a roomier cap.
-/// (codex P2.)
+/// there must leave headroom for the inherited daemon environment.
+///
+/// On Linux the binding limit is NOT ARG_MAX (the ~2 MiB total) but
+/// MAX_ARG_STRLEN: 128 KiB (32 × PAGE_SIZE) for any SINGLE argv/envp string,
+/// set by execve regardless of total size. A 512 KiB cap therefore admitted
+/// payloads that execve always rejects with E2BIG — observed in production as
+/// every queue dispatch dying at runner spawn with "Argument list too long"
+/// (TASK-001, 2026-09-02). Cap below 128 KiB with headroom for the key name.
+/// (codex P2, TASK-001.)
 #[cfg(windows)]
 const PHASE_SKILLS_ENV_MAX_BYTES: usize = 16 * 1024;
 #[cfg(not(windows))]
-const PHASE_SKILLS_ENV_MAX_BYTES: usize = 512 * 1024;
+const PHASE_SKILLS_ENV_MAX_BYTES: usize = 112 * 1024;
 
 /// Resolve the project's phase/profile skill declarations (same scoped
 /// sources and trust rules as the ad-hoc `--skill` path) and serialize the

--- a/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
+++ b/crates/orchestrator-daemon-runtime/src/dispatch/process_manager.rs
@@ -397,11 +397,20 @@ impl ProcessManager {
         let command_line: Vec<String> = std::iter::once(std_cmd.get_program().to_string_lossy().into_owned())
             .chain(std_cmd.get_args().map(|a| a.to_string_lossy().into_owned()))
             .collect();
+        let args_bytes: usize = command_line.iter().map(|a| a.len()).sum();
+        let builder_env_bytes: usize = std_cmd.get_envs().map(|(k, v)| k.len() + v.map(|v| v.len()).unwrap_or(0)).sum();
+        let program_path = std_cmd.get_program().to_string_lossy().into_owned();
         let mut command = Command::from(std_cmd);
         command.stdout(Stdio::null()).stderr(Stdio::piped());
+        // TASK-001: execve E2BIG ("Argument list too long") gives no hint which
+        // component overflowed. Track every injected block's size so a failed
+        // spawn reports the breakdown in its error context.
+        let mut injected_bytes: usize = 0;
         command.env_remove(ANIMUS_EXECUTION_FENCE_JSON_ENV);
         if let Some(execution) = execution_fence {
-            command.env(ANIMUS_EXECUTION_FENCE_JSON_ENV, serde_json::to_string(execution)?);
+            let fence_json = serde_json::to_string(execution)?;
+            injected_bytes += ANIMUS_EXECUTION_FENCE_JSON_ENV.len() + fence_json.len();
+            command.env(ANIMUS_EXECUTION_FENCE_JSON_ENV, fence_json);
         }
 
         // v0.5.1 P2 #6.2: pre-allocate the agent session id BEFORE spawn so
@@ -444,6 +453,7 @@ impl ProcessManager {
         // the runner when this dispatch produces none. (codex P2.)
         command.env_remove(animus_runtime_shared::phase_skills::ANIMUS_PHASE_SKILLS_ENV);
         if let Some(skills_json) = workflow_skills_env_payload(project_root) {
+            injected_bytes += animus_runtime_shared::phase_skills::ANIMUS_PHASE_SKILLS_ENV.len() + skills_json.len();
             command.env(animus_runtime_shared::phase_skills::ANIMUS_PHASE_SKILLS_ENV, skills_json);
         }
         // v0.5.8 secrets: inject keychain entries into the runner env so
@@ -492,6 +502,7 @@ impl ProcessManager {
                 command.env(&key, value);
                 total = next;
             }
+            injected_bytes += total;
         }
         #[cfg(unix)]
         let reattach_socket_path = reattach_socket_path_for(&project_root_path, &pending_session_id);
@@ -527,7 +538,15 @@ impl ProcessManager {
             command.env("ANIMUS_HOST_CLI_PATH", host_cli);
         }
 
-        let mut child = command.spawn().context("failed to spawn animus-workflow-runner")?;
+        let daemon_env_bytes: usize = std::env::vars_os().map(|(k, v)| k.len() + v.len() + 2).sum();
+        let mut child = command
+            .spawn()
+            .with_context(|| {
+                format!(
+                    "failed to spawn animus-workflow-runner (program={} args_bytes={} builder_env_bytes={} injected_env_bytes={} daemon_env_bytes={})",
+                    program_path, args_bytes, builder_env_bytes, injected_bytes, daemon_env_bytes,
+                )
+            })?;
 
         let stderr_lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let stderr_reader = if let Some(stderr) = child.stderr.take() {


### PR DESCRIPTION
## Root cause

Production evidence (runtime-v54, instrumented): every runner spawn failed with

```
failed to spawn animus-workflow-runner (program=…/plugins/animus-workflow-runner-default args_bytes=241 builder_env_bytes=17 injected_env_bytes=169668 daemon_env_bytes=8258): Argument list too long (os error 7)
```

The phase-skills payload (~166 KB) is set as ONE env var (`ANIMUS_PHASE_SKILLS`). The kernel's Unix cap of 512 KiB was justified by ARG_MAX (~2 MiB total), but Linux execve enforces **MAX_ARG_STRLEN = 128 KiB per single string**. Payloads in the 128 KiB–512 KiB window pass the kernel cap and then fail every spawn with E2BIG. Because the dispatch leg logged via tracing (invisible in hosted logs) and the queue plugin maps all terminal completions to `done`, this silently ate every queued dispatch since 08:20 UTC.

## Change

Cap the Unix phase-skills payload at 112 KiB (below MAX_ARG_STRLEN with headroom for the key name). Over-cap payloads already fall back to runner-local skill resolution by design, so no behavior is lost.

## Tests

cargo test -p orchestrator-daemon-runtime --lib: 340 pass.

## Follow-ups (not in this PR)

- Dedupe skill definitions across phases in the payload (the same profile's skills repeat per phase — that's what inflated past 128 KiB).
- Whatever grew the payload at ~08:20 (skill re-seed or profile change) is worth a look but is no longer fatal.
- animus-postgres queue plugin persists 'failed'/'cancelled' distinctly from 'completed' instead of collapsing to 'done'.