### PR TITLE
release: Animus CLI v0.7.0-rc.49

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,7 +2898,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.7.0-rc.48"
+version = "0.7.0-rc.49"
 dependencies = [
  "animus-actor",
  "animus-application-protocol",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 Open a fresh **Claude Code** (or **Codex** / **OpenCode** / **Cursor**) session and paste this. The agent installs the Animus CLI, clones `animus-skills`, runs the setup script, and adds the project section to `CLAUDE.md` / `AGENTS.md`. You'll be running workflows in about a minute.
 
-> Install Animus + Animus Skills: run **`curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash`** to install the `animus` CLI (currently `v0.7.0-rc.48` in this repo), then **`animus plugin install-defaults`** to pull in the provider + subject + workflow_runner + queue plugins the daemon needs (one-time setup, idempotent; add `--include-recommended` for the web UI and extra providers). Then **`git clone --single-branch --depth 1 https://github.com/launchapp-dev/animus-skills.git ~/.claude/skills/animus-skills && cd ~/.claude/skills/animus-skills && ./setup`** to link the skills and write `.mcp.json`. Add an "Animus" section to CLAUDE.md (or AGENTS.md for Codex) listing the slash commands: `/animus-setup`, `/animus-getting-started`, `/animus-mcp-setup`, `/animus-workflow-authoring`, `/animus-pack-authoring`, `/animus-skill-authoring`, `/animus-troubleshooting`. Restart the agent so the new `animus` MCP server is picked up. From a project root, run `animus init --walkthrough` to scaffold `.animus/`, install packs, and optionally start the daemon.
+> Install Animus + Animus Skills: run **`curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash`** to install the `animus` CLI (currently `v0.7.0-rc.49` in this repo), then **`animus plugin install-defaults`** to pull in the provider + subject + workflow_runner + queue plugins the daemon needs (one-time setup, idempotent; add `--include-recommended` for the web UI and extra providers). Then **`git clone --single-branch --depth 1 https://github.com/launchapp-dev/animus-skills.git ~/.claude/skills/animus-skills && cd ~/.claude/skills/animus-skills && ./setup`** to link the skills and write `.mcp.json`. Add an "Animus" section to CLAUDE.md (or AGENTS.md for Codex) listing the slash commands: `/animus-setup`, `/animus-getting-started`, `/animus-mcp-setup`, `/animus-workflow-authoring`, `/animus-pack-authoring`, `/animus-skill-authoring`, `/animus-troubleshooting`. Restart the agent so the new `animus` MCP server is picked up. From a project root, run `animus init --walkthrough` to scaffold `.animus/`, install packs, and optionally start the daemon.
 
 For Codex CLI, swap the clone path to `~/.codex/skills/animus-skills` and edit `AGENTS.md` instead of `CLAUDE.md`.
 
@@ -83,7 +83,7 @@ animus install --locked
 
 ```bash
 # Specific version
-ANIMUS_VERSION=v0.7.0-rc.48 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
+ANIMUS_VERSION=v0.7.0-rc.49 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
 
 # Custom directory
 ANIMUS_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.7.0-rc.48"
+version = "0.7.0-rc.49"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ if you are upgrading from an earlier v0.4.x.
 
 Use the installer published from `launchapp-dev/animus-cli`:
 
-Current workspace CLI version: **v0.7.0-rc.48**.
+Current workspace CLI version: **v0.7.0-rc.49**.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
@@ -28,7 +28,7 @@ Options:
 
 ```bash
 # Install a specific release
-ANIMUS_VERSION=v0.7.0-rc.48 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
+ANIMUS_VERSION=v0.7.0-rc.49 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
 
 # Install into a custom directory
 ANIMUS_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -15,7 +15,7 @@ time so the container boots without network access.
 ```dockerfile
 # ---- stage 1: fetch the prebuilt animus binary ----
 FROM debian:bookworm-slim AS animus-fetch
-ARG ANIMUS_VERSION=v0.7.0-rc.48
+ARG ANIMUS_VERSION=v0.7.0-rc.49
 ARG ANIMUS_TARGET=x86_64-unknown-linux-gnu
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -82,7 +82,7 @@ CMD ["/app/deploy/start.sh"]
 
 | ARG | Default | Description |
 |---|---|---|
-| `ANIMUS_VERSION` | `v0.7.0-rc.48` | Release tag to download from `launchapp-dev/animus-cli` |
+| `ANIMUS_VERSION` | `v0.7.0-rc.49` | Release tag to download from `launchapp-dev/animus-cli` |
 | `ANIMUS_TARGET` | `x86_64-unknown-linux-gnu` | Target triple; must match the container's glibc |
 | `SIG` | `--signature-policy=disabled` | Signature policy flag passed to every `plugin install` |
 


### PR DESCRIPTION
Version bump. Contents since rc.48: #404 (boot-time config source + env-broker engagement visibility, TASK-001). check-doc-sync + cargo check clean, Cargo.lock synced.