### PR TITLE
fix(mcp): support self-contained OAuth proxy handoff

### DIFF
--- a/crates/orchestrator-cli/src/bin/animus_mcp_proxy.rs
+++ b/crates/orchestrator-cli/src/bin/animus_mcp_proxy.rs
@@ -18,7 +18,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use orchestrator_config::workflow_config::OauthConfig;
 
@@ -43,6 +43,9 @@ struct Args {
     #[arg(long = "auth-code")]
     auth_code: bool,
 
+    #[arg(long)]
+    oauth_config_json: Option<String>,
+
     /// Project root. Defaults to the current working directory.
     #[arg(long)]
     project_root: Option<PathBuf>,
@@ -57,6 +60,13 @@ struct BrokerBearerSource {
     server: String,
     project_root: String,
     oauth: OauthConfig,
+}
+
+fn explicit_oauth_config(args: &Args) -> Result<Option<OauthConfig>> {
+    args.oauth_config_json
+        .as_deref()
+        .map(|raw| serde_json::from_str(raw).context("invalid --oauth-config-json value"))
+        .transpose()
 }
 
 impl animus_mcp_oauth::proxy::BearerTokenSource for BrokerBearerSource {
@@ -85,10 +95,26 @@ async fn async_main() -> Result<()> {
     let args = Args::parse();
     let project_root = args
         .project_root
+        .as_ref()
         .map(|p| p.display().to_string())
         .or_else(|| std::env::current_dir().ok().map(|p| p.display().to_string()))
         .unwrap_or_else(|| ".".to_string());
     let root = std::path::Path::new(&project_root);
+
+    if let Some(oauth) = explicit_oauth_config(&args)? {
+        let url = args
+            .url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("--url is required when --oauth-config-json is provided"))?;
+        if oauth.flow == orchestrator_config::workflow_config::OauthFlow::AuthorizationCode {
+            return animus_mcp_oauth::proxy::run_authorization_code(&args.server, url, root).await;
+        }
+        let source =
+            Arc::new(BrokerBearerSource { server: args.server.clone(), project_root: project_root.clone(), oauth });
+        return animus_mcp_oauth::proxy::run_with_bearer_source(&args.server, url, source).await;
+    }
 
     // Fast path: the caller already resolved an `authorization_code` (keychain)
     // server and handed us the upstream `--url`. Trust it and skip the
@@ -117,5 +143,39 @@ async fn async_main() -> Result<()> {
             animus_mcp_oauth::proxy::run_with_bearer_source(&args.server, &resolution.url, source).await
         }
         None => animus_mcp_oauth::proxy::run_authorization_code(&args.server, &resolution.url, root).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use orchestrator_config::workflow_config::OauthFlow;
+
+    #[test]
+    fn explicit_oauth_config_parses_without_loading_project_config() {
+        let args = Args::try_parse_from([
+            "animus-mcp-proxy",
+            "--server",
+            "rental-v1",
+            "--url",
+            "https://example.test/mcp",
+            "--oauth-config-json",
+            r#"{"flow":"manual_bearer","bearer_env":"RENTAL_MCP_BEARER"}"#,
+        ])
+        .expect("args");
+
+        let config = explicit_oauth_config(&args).expect("config").expect("explicit config");
+        assert_eq!(config.flow, OauthFlow::ManualBearer);
+        assert_eq!(config.bearer_env.as_deref(), Some("RENTAL_MCP_BEARER"));
+    }
+
+    #[test]
+    fn explicit_oauth_config_rejects_invalid_json() {
+        let args =
+            Args::try_parse_from(["animus-mcp-proxy", "--server", "rental-v1", "--oauth-config-json", "not-json"])
+                .expect("args");
+
+        assert!(explicit_oauth_config(&args).is_err());
     }
 }

--- a/docs/reference/mcp-oauth.md
+++ b/docs/reference/mcp-oauth.md
@@ -256,6 +256,12 @@ assembler, not by hand, but can be run directly:
 animus-mcp-proxy --server github [--url https://api.githubcopilot.com/mcp/] [--project-root .]
 ```
 
+Runtime assemblers can pass `--oauth-config-json <JSON>` together with
+`--url`. This self-contained handoff skips project workflow-config loading,
+which lets the proxy run inside a provider's restricted environment. The JSON
+uses the same `oauth:` schema documented above; credential values still arrive
+through the named environment variables rather than the argument.
+
 It serves the agent an auth-free stdio MCP endpoint and forwards to the
 upstream with a live bearer token:
 


### PR DESCRIPTION
## Root cause
A proxy spawned inside a provider session has a deliberately restricted environment. The existing proxy always loaded the project workflow config for broker-backed OAuth flows, which requires Portal database and validation settings that are not available inside that boundary.

## Change
- Add an explicit OAuth-config handoff for trusted runtime assemblers.
- Require an explicit upstream URL on that path.
- Resolve tokens directly from the supplied non-secret OAuth metadata and the named entry environment variables.
- Preserve the existing config-source path for normal direct invocation.
- Document the internal handoff.

Credential values are not placed in arguments; the JSON contains OAuth schema metadata and environment-variable names only.

## Verification
- cargo test -p orchestrator-cli --bin animus-mcp-proxy
- cargo build -p orchestrator-cli --bin animus-mcp-proxy
- cargo animus-fmt --check
- cargo animus-lint
- cargo animus-bin-check
- cargo test --workspace: all relevant suites passed; one unrelated parallel workflow-state test failed once and passed in isolation
- scrubbed-environment manual-bearer probe reached the configured upstream without attempting project config or database loading

## Release impact
Requires a new animus-cli release and coordinated Portal runtime pin before the Rental production canary.