### PR TITLE
fix(config): permit OAuth proxy credential env; prepare rc.52 (TASK-1503)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,7 +2898,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestrator-cli"
-version = "0.7.0-rc.51"
+version = "0.7.0-rc.52"
 dependencies = [
  "animus-actor",
  "animus-application-protocol",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 Open a fresh **Claude Code** (or **Codex** / **OpenCode** / **Cursor**) session and paste this. The agent installs the Animus CLI, clones `animus-skills`, runs the setup script, and adds the project section to `CLAUDE.md` / `AGENTS.md`. You'll be running workflows in about a minute.
 
-> Install Animus + Animus Skills: run **`curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash`** to install the `animus` CLI (currently `v0.7.0-rc.51` in this repo), then **`animus plugin install-defaults`** to pull in the provider + subject + workflow_runner + queue plugins the daemon needs (one-time setup, idempotent; add `--include-recommended` for the web UI and extra providers). Then **`git clone --single-branch --depth 1 https://github.com/launchapp-dev/animus-skills.git ~/.claude/skills/animus-skills && cd ~/.claude/skills/animus-skills && ./setup`** to link the skills and write `.mcp.json`. Add an "Animus" section to CLAUDE.md (or AGENTS.md for Codex) listing the slash commands: `/animus-setup`, `/animus-getting-started`, `/animus-mcp-setup`, `/animus-workflow-authoring`, `/animus-pack-authoring`, `/animus-skill-authoring`, `/animus-troubleshooting`. Restart the agent so the new `animus` MCP server is picked up. From a project root, run `animus init --walkthrough` to scaffold `.animus/`, install packs, and optionally start the daemon.
+> Install Animus + Animus Skills: run **`curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash`** to install the `animus` CLI (currently `v0.7.0-rc.52` in this repo), then **`animus plugin install-defaults`** to pull in the provider + subject + workflow_runner + queue plugins the daemon needs (one-time setup, idempotent; add `--include-recommended` for the web UI and extra providers). Then **`git clone --single-branch --depth 1 https://github.com/launchapp-dev/animus-skills.git ~/.claude/skills/animus-skills && cd ~/.claude/skills/animus-skills && ./setup`** to link the skills and write `.mcp.json`. Add an "Animus" section to CLAUDE.md (or AGENTS.md for Codex) listing the slash commands: `/animus-setup`, `/animus-getting-started`, `/animus-mcp-setup`, `/animus-workflow-authoring`, `/animus-pack-authoring`, `/animus-skill-authoring`, `/animus-troubleshooting`. Restart the agent so the new `animus` MCP server is picked up. From a project root, run `animus init --walkthrough` to scaffold `.animus/`, install packs, and optionally start the daemon.
 
 For Codex CLI, swap the clone path to `~/.codex/skills/animus-skills` and edit `AGENTS.md` instead of `CLAUDE.md`.
 
@@ -83,7 +83,7 @@ animus install --locked
 
 ```bash
 # Specific version
-ANIMUS_VERSION=v0.7.0-rc.51 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
+ANIMUS_VERSION=v0.7.0-rc.52 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
 
 # Custom directory
 ANIMUS_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash

--- a/crates/orchestrator-cli/Cargo.toml
+++ b/crates/orchestrator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator-cli"
-version = "0.7.0-rc.51"
+version = "0.7.0-rc.52"
 edition = "2021"
 license = "Elastic-2.0"
 default-run = "animus"

--- a/crates/orchestrator-config/src/workflow_config/tests.rs
+++ b/crates/orchestrator-config/src/workflow_config/tests.rs
@@ -3569,6 +3569,32 @@ fn validation_rejects_client_credentials_missing_client_secret_env() {
 }
 
 #[test]
+fn validation_accepts_http_oauth_proxy_env_but_rejects_direct_http_env() {
+    let mut config = builtin_workflow_config();
+    let mut server = http_oauth_server(OauthConfig {
+        flow: OauthFlow::ManualBearer,
+        token_url: None,
+        client_id_env: None,
+        client_secret_env: None,
+        refresh_token_env: None,
+        bearer_env: Some("RENTAL_MCP_BEARER".to_string()),
+        scopes: vec![],
+        audience: None,
+        cache: true,
+        client_id: None,
+    });
+    server.env.insert("RENTAL_MCP_BEARER".to_string(), "${secret.RENTAL_MCP_BEARER}".to_string());
+    config.mcp_servers.insert("rental-v1".to_string(), server);
+    validate_workflow_config(&config).expect("OAuth proxy must accept its credential environment");
+    let encoded = serde_json::to_string(&config).expect("serialize compiled config");
+    let decoded = serde_json::from_str(&encoded).expect("deserialize compiled config");
+    validate_workflow_config(&decoded).expect("compiled OAuth config must remain valid");
+    config.mcp_servers.get_mut("rental-v1").unwrap().oauth = None;
+    let err = validate_workflow_config(&config).expect_err("direct HTTP has no child environment");
+    assert!(err.to_string().contains("env must not be set"));
+}
+
+#[test]
 fn validation_rejects_manual_bearer_without_bearer_env() {
     let mut config = builtin_workflow_config();
     config.mcp_servers.insert(

--- a/crates/orchestrator-config/src/workflow_config/validation.rs
+++ b/crates/orchestrator-config/src/workflow_config/validation.rs
@@ -765,7 +765,7 @@ pub fn validate_workflow_config_with_project_root(config: &WorkflowConfig, proje
                 if !definition.args.is_empty() {
                     errors.push(format!("mcp_servers['{}'].args must not be set when transport is \"http\"", name));
                 }
-                if !definition.env.is_empty() {
+                if !definition.env.is_empty() && definition.oauth.is_none() {
                     errors.push(format!("mcp_servers['{}'].env must not be set when transport is \"http\"", name));
                 }
             }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ if you are upgrading from an earlier v0.4.x.
 
 Use the installer published from `launchapp-dev/animus-cli`:
 
-Current workspace CLI version: **v0.7.0-rc.51**.
+Current workspace CLI version: **v0.7.0-rc.52**.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
@@ -28,7 +28,7 @@ Options:
 
 ```bash
 # Install a specific release
-ANIMUS_VERSION=v0.7.0-rc.51 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
+ANIMUS_VERSION=v0.7.0-rc.52 curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash
 
 # Install into a custom directory
 ANIMUS_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/launchapp-dev/animus-cli/main/scripts/install.sh | bash

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -15,7 +15,7 @@ time so the container boots without network access.
 ```dockerfile
 # ---- stage 1: fetch the prebuilt animus binary ----
 FROM debian:bookworm-slim AS animus-fetch
-ARG ANIMUS_VERSION=v0.7.0-rc.51
+ARG ANIMUS_VERSION=v0.7.0-rc.52
 ARG ANIMUS_TARGET=x86_64-unknown-linux-gnu
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -82,7 +82,7 @@ CMD ["/app/deploy/start.sh"]
 
 | ARG | Default | Description |
 |---|---|---|
-| `ANIMUS_VERSION` | `v0.7.0-rc.51` | Release tag to download from `launchapp-dev/animus-cli` |
+| `ANIMUS_VERSION` | `v0.7.0-rc.52` | Release tag to download from `launchapp-dev/animus-cli` |
 | `ANIMUS_TARGET` | `x86_64-unknown-linux-gnu` | Target triple; must match the container's glibc |
 | `SIG` | `--signature-policy=disabled` | Signature policy flag passed to every `plugin install` |
 


### PR DESCRIPTION
HTTP MCP definitions with OAuth are rewritten into local proxy processes, but workflow validation rejects every nonempty env map before that rewrite. Rental's documented secret-reference configuration therefore invalidates the whole workflow config.

Allow env only when the HTTP definition carries OAuth, preserving the restriction for direct HTTP servers and all existing OAuth validation. Add regression coverage for manual-bearer secret refs and compiled JSON round-trip. Prepare v0.7.0-rc.52 and synchronize version documentation.

Validation: all 462 orchestrator-config tests passed; config all-target clippy with warnings denied, workspace formatting, and docs-sync passed. Production v61 was activated but its incompatible Rental env addition was rolled back; TASK-1503 remains open until rc.52 is released, pinned, activated, and tested with a live Rental workflow.